### PR TITLE
Allow party_type filter in party search select to fix failing tests

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -1,5 +1,13 @@
 # SESSIONS - Historical Decisions & Milestones
 
+## 2026-07-09 (Corrección de fallos en filtros del buscador asistido 'search-select' para terceros)
+- **Solicitud:** Investigar y corregir los fallos en las pruebas automatizadas (específicamente la prueba E2E de autocompletado con múltiples fuentes: `test_transaction_form_multi_source_autofill`).
+- **Diagnóstico:** El frontend enviaba el filtro `party_type` al buscar terceros vía `/api/search-select?doctype=party&q=Demo&company=cacao&party_type=customer`. Sin embargo, la especificación de búsqueda de `Party` (`party`, `customer`, `supplier`) en `cacao_accounting/search_select.py` sólo admitía el filtro `role`. Al recibir el parámetro desconocido `party_type`, el backend devolvía error HTTP 400 ("Filtros no permitidos: party_type"), lo que causaba que la búsqueda de Cliente Demo fallara y la prueba E2E fallara por timeout.
+- **Implementación:**
+  - Se modificaron las especificaciones de búsqueda para `party`, `customer` y `supplier` en `_SEARCH_SELECT_REGISTRY` en `cacao_accounting/search_select.py` para admitir `"party_type"` como un filtro válido, mapeándolo al campo de validación de rol de base de datos (`"role"`).
+  - Se actualizó `_apply_request_filters` para capturar tanto `"role"` como `"party_type"` para los modelos de terceros (`Party`) y aplicar la lógica unificada de `_apply_role_filter`.
+- **Pruebas:** Se verificaron con éxito la prueba E2E (`tests/test_e2e_transactional_ui.py`) y la prueba de conciliación (`tests/test_08_reconciliation_reports.py`).
+
 ## 2026-07-09 (Cierre de los 4 hallazgos reales pendientes de ISSUES.md)
 - **Solicitud:** Preparar y ejecutar el plan para corregir los issues pendientes R2R-04, O2C-04, S2P-09 y S2P-07, con commits semánticos firmados (sign-off) como williamjmorenor@gmail.com.
 - **Decisiones de diseño:**

--- a/cacao_accounting/search_select.py
+++ b/cacao_accounting/search_select.py
@@ -381,7 +381,7 @@ _SEARCH_SELECT_REGISTRY: dict[str, SearchSelectSpec] = {
         search_fields=("code", "name", "comercial_name", "tax_id"),
         value_field="id",
         label_builder=_party_label,
-        allowed_filters={"company": "company", "role": "role", "is_active": "is_active"},
+        allowed_filters={"company": "company", "role": "role", "party_type": "role", "is_active": "is_active"},
         default_filters={"is_active": True},
     ),
     "party_group": SearchSelectSpec(
@@ -417,7 +417,7 @@ _SEARCH_SELECT_REGISTRY: dict[str, SearchSelectSpec] = {
         search_fields=("code", "name", "comercial_name", "tax_id"),
         value_field="id",
         label_builder=_party_label,
-        allowed_filters={"company": "company", "role": "role", "is_active": "is_active"},
+        allowed_filters={"company": "company", "role": "role", "party_type": "role", "is_active": "is_active"},
         default_filters={"role": "customer", "is_active": True},
     ),
     "supplier": SearchSelectSpec(
@@ -426,7 +426,7 @@ _SEARCH_SELECT_REGISTRY: dict[str, SearchSelectSpec] = {
         search_fields=("code", "name", "comercial_name", "tax_id"),
         value_field="id",
         label_builder=_party_label,
-        allowed_filters={"company": "company", "role": "role", "is_active": "is_active"},
+        allowed_filters={"company": "company", "role": "role", "party_type": "role", "is_active": "is_active"},
         default_filters={"role": "supplier", "is_active": True},
     ),
     "item": SearchSelectSpec(
@@ -721,7 +721,7 @@ def _apply_request_filters(
         if spec.model is Party and filter_name == "company":
             statement = statement.where(CompanyParty.company.in_(clean_values))
             continue
-        if spec.model is Party and filter_name == "role":
+        if spec.model is Party and filter_name in ("role", "party_type"):
             statement = _apply_role_filter(statement, clean_values)
             continue
         column = _column_for(spec.model, spec.allowed_filters[filter_name])

--- a/cacao_accounting/search_select.py
+++ b/cacao_accounting/search_select.py
@@ -737,6 +737,8 @@ def _apply_role_filter(statement: Select[tuple[Any]], values: Sequence[str | boo
             conditions.append(Party.is_customer.is_(True))
         elif sv == "supplier":
             conditions.append(Party.is_supplier.is_(True))
+        else:
+            raise SearchSelectError(f"Tipo de tercero o rol no soportado: {sv}")
     if conditions:
         statement = statement.where(or_(*conditions))
     return statement

--- a/tests/test_09_journal_entry_form.py
+++ b/tests/test_09_journal_entry_form.py
@@ -744,6 +744,8 @@ def test_search_select_supports_journal_doctypes_and_filters(app_ctx):
     )
     assert client.get("/api/search-select?doctype=report_status&q=conta").json["results"][0]["value"] == "submitted"
     assert client.get("/api/search-select?doctype=book&q=Fiscal&bad_filter=x").status_code == 400
+    assert client.get("/api/search-select?doctype=party&party_type=employee").status_code == 400
+    assert client.get("/api/search-select?doctype=party&role=employee").status_code == 400
 
 
 def test_form_preferences_are_persisted_per_user(app_ctx):


### PR DESCRIPTION
This PR fixes the failing tests (specifically test_transaction_form_multi_source_autofill in tests/test_e2e_transactional_ui.py) by allowing the 'party_type' query parameter to filter parties by role in /api/search-select, matching what the frontend actually requests.

---
*PR created automatically by Jules for task [16718849231397728515](https://jules.google.com/task/16718849231397728515) started by @williamjmorenor*