### PR TITLE
Fix sales over-delivery and over-billing controls

### DIFF
--- a/cacao_accounting/ventas/__init__.py
+++ b/cacao_accounting/ventas/__init__.py
@@ -40,7 +40,7 @@ from cacao_accounting.document_flow import (
     revert_relations_for_target,
     validate_submit_prerequisites,
 )
-from cacao_accounting.document_flow.repository import has_active_source_relations
+from cacao_accounting.document_flow.repository import consumed_qty_for_source, has_active_source_relations
 from cacao_accounting.document_flow.status import _
 from cacao_accounting.decorators import modulo_activo, verifica_acceso as verifica_acceso  # noqa: F401
 from cacao_accounting.fiscal_persistence_service import persist_document_fiscal_snapshot
@@ -1311,6 +1311,72 @@ def _validate_invoice_prices_against_source(invoice: SalesInvoice, raise_on_viol
     return warnings
 
 
+def _validate_delivery_quantities_against_so(note_id: str) -> None:
+    """Valida que las cantidades entregadas no excedan las ordenadas en la Orden de Venta."""
+    relations = database.session.execute(
+        database.select(DocumentRelation).filter_by(
+            target_type="delivery_note",
+            target_id=note_id,
+            status="active",
+        )
+    ).scalars()
+    for rel in relations:
+        if rel.source_type != "sales_order" or not rel.source_item_id:
+            continue
+        so_item = database.session.get(SalesOrderItem, rel.source_item_id)
+        if not so_item:
+            continue
+        consumed = consumed_qty_for_source("sales_order", rel.source_id, rel.source_item_id, "delivery_note")
+        ordered = Decimal(str(so_item.qty or 0))
+        if consumed > ordered:
+            raise ValueError(
+                _("Sobre-entrega: cantidad entregada {} excede la ordenada {} para el artículo {}.").format(
+                    consumed, ordered, so_item.item_code
+                )
+            )
+
+
+def _validate_sales_invoice_quantities(invoice_id: str) -> None:
+    """Valida que las cantidades facturadas no excedan las entregadas en la Nota de Entrega
+
+    o las ordenadas en la Orden de Venta.
+    """
+    relations = database.session.execute(
+        database.select(DocumentRelation).filter_by(
+            target_type="sales_invoice",
+            target_id=invoice_id,
+            status="active",
+        )
+    ).scalars()
+    for rel in relations:
+        if not rel.source_item_id:
+            continue
+        if rel.source_type == "delivery_note":
+            dn_item = database.session.get(DeliveryNoteItem, rel.source_item_id)
+            if not dn_item:
+                continue
+            consumed = consumed_qty_for_source("delivery_note", rel.source_id, rel.source_item_id, "sales_invoice")
+            delivered = Decimal(str(dn_item.qty or 0))
+            if consumed > delivered:
+                raise ValueError(
+                    _("Sobre-facturación: cantidad facturada {} excede la entregada {} para el artículo {}.").format(
+                        consumed, delivered, dn_item.item_code
+                    )
+                )
+        elif rel.source_type == "sales_order":
+            so_item = database.session.get(SalesOrderItem, rel.source_item_id)
+            if not so_item:
+                continue
+            consumed = consumed_qty_for_source("sales_order", rel.source_id, rel.source_item_id, "sales_invoice")
+            ordered = Decimal(str(so_item.qty or 0))
+            if consumed > ordered:
+                raise ValueError(
+                    _("Sobre-facturación: cantidad facturada {} excede la ordenada {} para el artículo {}.").format(
+                        consumed, ordered, so_item.item_code
+                    )
+                )
+
+
 def _persist_sales_invoice_fiscal_snapshot(invoice: SalesInvoice) -> None:
     """Persist the editable fiscal snapshot captured in the form."""
     persist_document_fiscal_snapshot(
@@ -2251,6 +2317,7 @@ def ventas_entrega_submit(note_id: str):
             require_rate_positive=True,
             require_amount_nonzero=True,
         )
+        _validate_delivery_quantities_against_so(note_id)
         submit_document(registro)
         _release_reservation_for_delivery_note(registro)
         log_submit(registro)
@@ -2627,6 +2694,7 @@ def ventas_factura_venta_submit(invoice_id: str):
             require_rate_positive=True,
             require_amount_nonzero=True,
         )
+        _validate_sales_invoice_quantities(invoice_id)
         warnings = _validate_invoice_prices_against_source(registro)
         submit_document(registro)
         if registro.update_inventory and not registro.delivery_note_id:

--- a/cacao_accounting/ventas/__init__.py
+++ b/cacao_accounting/ventas/__init__.py
@@ -1337,10 +1337,7 @@ def _validate_delivery_quantities_against_so(note_id: str) -> None:
 
 
 def _validate_sales_invoice_quantities(invoice_id: str) -> None:
-    """Valida que las cantidades facturadas no excedan las entregadas en la Nota de Entrega
-
-    o las ordenadas en la Orden de Venta.
-    """
+    """Valida cantidades facturadas contra Nota de Entrega u Orden de Venta."""
     relations = database.session.execute(
         database.select(DocumentRelation).filter_by(
             target_type="sales_invoice",

--- a/tests/test_o2c_sales_fixes.py
+++ b/tests/test_o2c_sales_fixes.py
@@ -255,3 +255,140 @@ def test_create_document_relation_rejects_cancelled_source(app_ctx):
             target_item_id=si_item.id,
             qty=Decimal("1"),
         )
+
+
+def test_over_delivery_validation(app_ctx):
+    from cacao_accounting.database import DeliveryNote, DeliveryNoteItem
+    from cacao_accounting.ventas import _validate_delivery_quantities_against_so
+
+    _ensure_item("ART-RESERVE")
+    customer = _ensure_customer("CUST-O2C25", "Cliente O2C25")
+
+    # 1. Crear y aprobar una Orden de Venta por 10 unidades.
+    so = SalesOrder(customer_id=customer.id, company="cacao", posting_date=date.today(), docstatus=1)
+    database.session.add(so)
+    database.session.flush()
+    so_item = SalesOrderItem(sales_order_id=so.id, item_code="ART-RESERVE", qty=Decimal("10"), rate=Decimal("5"))
+    database.session.add(so_item)
+    database.session.flush()
+
+    # 2. Crear una Nota de Entrega asociada a esta Orden de Venta por 12 unidades (invalida).
+    dn = DeliveryNote(customer_id=customer.id, company="cacao", posting_date=date.today(), docstatus=0)
+    database.session.add(dn)
+    database.session.flush()
+    dn_item = DeliveryNoteItem(delivery_note_id=dn.id, item_code="ART-RESERVE", qty=Decimal("12"), rate=Decimal("5"))
+    database.session.add(dn_item)
+    database.session.flush()
+
+    # Create document relation between SO item and DN item
+    database.session.add(
+        DocumentRelation(
+            source_type="sales_order",
+            source_id=so.id,
+            source_item_id=so_item.id,
+            target_type="delivery_note",
+            target_id=dn.id,
+            target_item_id=dn_item.id,
+            qty=Decimal("12"),
+            relation_type="fulfillment",
+            status="active",
+        )
+    )
+    database.session.commit()
+
+    # 3. Intentar aprobar la Nota de Entrega (debe lanzar ValueError por sobre-entrega)
+    with pytest.raises(ValueError) as excinfo:
+        _validate_delivery_quantities_against_so(dn.id)
+    assert "Sobre-entrega" in str(excinfo.value)
+
+    # Now let's change the DN quantity to 10 (valid) and check it passes
+    dn_item.qty = Decimal("10")
+    # Also need to update the DocumentRelation qty to 10
+    rel = database.session.execute(
+        database.select(DocumentRelation).filter_by(
+            target_type="delivery_note",
+            target_id=dn.id,
+            target_item_id=dn_item.id,
+        )
+    ).scalar_one()
+    rel.qty = Decimal("10")
+    database.session.commit()
+
+    # This should not raise any exceptions
+    _validate_delivery_quantities_against_so(dn.id)
+
+
+def test_over_billing_validation(app_ctx):
+    from cacao_accounting.database import DeliveryNote, DeliveryNoteItem
+    from cacao_accounting.ventas import _validate_sales_invoice_quantities
+
+    _ensure_item("ART-RESERVE")
+    customer = _ensure_customer("CUST-O2C26", "Cliente O2C26")
+
+    # Flow 1: Direct sales order billing over-billing
+    so = SalesOrder(customer_id=customer.id, company="cacao", posting_date=date.today(), docstatus=1)
+    database.session.add(so)
+    database.session.flush()
+    so_item = SalesOrderItem(sales_order_id=so.id, item_code="ART-RESERVE", qty=Decimal("10"), rate=Decimal("5"))
+    database.session.add(so_item)
+    database.session.flush()
+
+    si1 = SalesInvoice(customer_id=customer.id, company="cacao", posting_date=date.today(), docstatus=0)
+    database.session.add(si1)
+    database.session.flush()
+    si1_item = SalesInvoiceItem(sales_invoice_id=si1.id, item_code="ART-RESERVE", qty=Decimal("11"), rate=Decimal("5"))
+    database.session.add(si1_item)
+    database.session.flush()
+
+    database.session.add(
+        DocumentRelation(
+            source_type="sales_order",
+            source_id=so.id,
+            source_item_id=so_item.id,
+            target_type="sales_invoice",
+            target_id=si1.id,
+            target_item_id=si1_item.id,
+            qty=Decimal("11"),
+            relation_type="fulfillment",
+            status="active",
+        )
+    )
+    database.session.commit()
+
+    with pytest.raises(ValueError) as excinfo:
+        _validate_sales_invoice_quantities(si1.id)
+    assert "Sobre-facturación" in str(excinfo.value)
+
+    # Flow 2: Delivery Note billing over-billing
+    dn = DeliveryNote(customer_id=customer.id, company="cacao", posting_date=date.today(), docstatus=1)
+    database.session.add(dn)
+    database.session.flush()
+    dn_item = DeliveryNoteItem(delivery_note_id=dn.id, item_code="ART-RESERVE", qty=Decimal("5"), rate=Decimal("5"))
+    database.session.add(dn_item)
+    database.session.flush()
+
+    si2 = SalesInvoice(customer_id=customer.id, company="cacao", posting_date=date.today(), docstatus=0)
+    database.session.add(si2)
+    database.session.flush()
+    si2_item = SalesInvoiceItem(sales_invoice_id=si2.id, item_code="ART-RESERVE", qty=Decimal("7"), rate=Decimal("5"))
+    database.session.add(si2_item)
+    database.session.flush()
+
+    database.session.add(
+        DocumentRelation(
+            source_type="delivery_note",
+            source_id=dn.id,
+            source_item_id=dn_item.id,
+            target_type="sales_invoice",
+            target_id=si2.id,
+            target_item_id=si2_item.id,
+            qty=Decimal("7"),
+            relation_type="fulfillment",
+            status="active",
+        )
+    )
+    database.session.commit()
+
+    with pytest.raises(ValueError) as excinfo:
+        _validate_sales_invoice_quantities(si2.id)
+    assert "Sobre-facturación" in str(excinfo.value)


### PR DESCRIPTION
Implements validation logic to prevent over-delivery on Delivery Notes (linked to Sales Orders) and over-billing on Sales Invoices (linked to either Sales Orders or Delivery Notes) on document submission in the Ventas (Sales) module under issues O2C-25 and O2C-26. Also adds robust unit test coverage.

---
*PR created automatically by Jules for task [7816845221480268562](https://jules.google.com/task/7816845221480268562) started by @williamjmorenor*