### PR TITLE
Prevent Duplicate Supplier Invoice Number

### DIFF
--- a/cacao_accounting/compras/__init__.py
+++ b/cacao_accounting/compras/__init__.py
@@ -2965,6 +2965,35 @@ def _validate_supplier_invoice_flags(
         raise ValueError("El proveedor no permite crear facturas de compra sin recepción.")
 
 
+def _validate_duplicate_supplier_invoice(
+    supplier_id: str | None, supplier_invoice_no: str | None, exclude_id: str | None = None
+) -> None:
+    """S2P-24: Valida que no exista otra factura de compra activa (no cancelada, docstatus != 2)
+    con el mismo supplier_id y supplier_invoice_no.
+    """
+    if not supplier_id or not supplier_invoice_no:
+        return
+    supplier_invoice_no_cleaned = supplier_invoice_no.strip()
+    if not supplier_invoice_no_cleaned:
+        return
+
+    stmt = database.select(PurchaseInvoice).filter(
+        PurchaseInvoice.supplier_id == supplier_id,
+        PurchaseInvoice.supplier_invoice_no == supplier_invoice_no_cleaned,
+        PurchaseInvoice.docstatus != 2,
+    )
+    if exclude_id:
+        stmt = stmt.filter(PurchaseInvoice.id != exclude_id)
+
+    exists = database.session.execute(stmt).scalars().first()
+    if exists:
+        raise ValueError(
+            _(
+                "El número de factura del proveedor '{}' ya está registrado para este proveedor en otra factura activa."
+            ).format(supplier_invoice_no_cleaned)
+        )
+
+
 def _create_purchase_invoice_from_request():
     """Create a purchase invoice from the submitted form."""
     try:
@@ -2975,6 +3004,7 @@ def _create_purchase_invoice_from_request():
         from_order = request.form.get("from_order") or None
         from_receipt = request.form.get("from_receipt") or None
         _validate_supplier_invoice_flags(supplier_id, company, from_order, from_receipt)
+        _validate_duplicate_supplier_invoice(supplier_id, request.form.get("supplier_invoice_no"))
         factura = PurchaseInvoice(
             supplier_id=supplier_id,
             company=company,
@@ -3140,6 +3170,11 @@ def _handle_purchase_invoice_edit_post(registro):
             request.form.get("from_order") or None,
             request.form.get("from_receipt") or None,
         )
+        _validate_duplicate_supplier_invoice(
+            registro.supplier_id,
+            request.form.get("supplier_invoice_no") or registro.supplier_invoice_no,
+            exclude_id=registro.id,
+        )
         registro.posting_date = _parse_date(request.form.get("posting_date"))
         registro.supplier_invoice_no = request.form.get("supplier_invoice_no") or registro.supplier_invoice_no
         registro.remarks = request.form.get("remarks")
@@ -3257,6 +3292,11 @@ def compras_factura_compra_submit(invoice_id: str):
             getattr(registro, "company", None),
             getattr(registro, "purchase_order_id", None),
             getattr(registro, "purchase_receipt_id", None),
+        )
+        _validate_duplicate_supplier_invoice(
+            getattr(registro, "supplier_id", None),
+            getattr(registro, "supplier_invoice_no", None),
+            exclude_id=registro.id,
         )
         submit_document(registro)
         log_submit(registro)

--- a/cacao_accounting/compras/__init__.py
+++ b/cacao_accounting/compras/__init__.py
@@ -2968,7 +2968,9 @@ def _validate_supplier_invoice_flags(
 def _validate_duplicate_supplier_invoice(
     supplier_id: str | None, supplier_invoice_no: str | None, exclude_id: str | None = None
 ) -> None:
-    """S2P-24: Valida que no exista otra factura de compra activa (no cancelada, docstatus != 2)
+    """S2P-24: Valida la duplicidad de supplier_invoice_no para un mismo proveedor.
+
+    Valida que no exista otra factura de compra activa (no cancelada, docstatus != 2)
     con el mismo supplier_id y supplier_invoice_no.
     """
     if not supplier_id or not supplier_invoice_no:

--- a/cacao_accounting/database/__init__.py
+++ b/cacao_accounting/database/__init__.py
@@ -1310,12 +1310,16 @@ class PurchaseReceiptItem(database.Model, BaseTabla):  # type: ignore[name-defin
 
 
 class PurchaseInvoice(database.Model, DocBase):  # type: ignore[name-defined]
-    """Factura de compra."""
+    """Factura de compra.
+
+    S2P-24: El número de factura física del proveedor (supplier_invoice_no) para un mismo
+    proveedor (supplier_id) debe ser único entre todas las facturas activas (no canceladas).
+    """
 
     __tablename__ = "purchase_invoice"
     supplier_id = database.Column(database.String(26), database.ForeignKey(PARTY_ID), nullable=True, index=True)
     supplier_name = database.Column(database.String(200), nullable=True)
-    supplier_invoice_no = database.Column(database.String(50), nullable=True)
+    supplier_invoice_no = database.Column(database.String(50), nullable=True)  # Validado contra duplicados
     document_type = database.Column(database.String(50), nullable=False, default="purchase_invoice")
     is_return = database.Column(database.Boolean(), default=False, nullable=False)
     purchase_order_id = database.Column(database.String(26), database.ForeignKey(PURCHASE_ORDER_ID), nullable=True, index=True)

--- a/tests/test_05document_flow.py
+++ b/tests/test_05document_flow.py
@@ -1231,3 +1231,104 @@ def test_invoice_submit_rejects_over_invoice(app_ctx):
 
     with pytest.raises(ValueError, match="Sobre-facturación"):
         _validate_invoice_quantities_against_receipt("PI-OVR-01")
+
+
+def test_supplier_invoice_no_duplication_validation(app_ctx):
+    """S2P-24: Valida la duplicidad de supplier_invoice_no para un mismo proveedor."""
+    from cacao_accounting.database import PurchaseInvoice, CompanyParty, database
+    from cacao_accounting.compras import _validate_duplicate_supplier_invoice
+
+    # Setup suppliers in company party
+    cp1 = CompanyParty(
+        party_id="SUPLR-00001",
+        company="cacao",
+        allow_purchase_invoice_without_order=True,
+        allow_purchase_invoice_without_receipt=True,
+    )
+    cp2 = CompanyParty(
+        party_id="SUPLR-00002",
+        company="cacao",
+        allow_purchase_invoice_without_order=True,
+        allow_purchase_invoice_without_receipt=True,
+    )
+    database.session.add_all([cp1, cp2])
+    database.session.commit()
+
+    # Case 1: First invoice, draft status
+    invoice1 = PurchaseInvoice(
+        id="INV-001",
+        supplier_id="SUPLR-00001",
+        company="cacao",
+        supplier_invoice_no="FAC-2026-001",
+        docstatus=0,
+    )
+    database.session.add(invoice1)
+    database.session.commit()
+
+    # Attempting to validate a new invoice with same supplier & same invoice number must fail.
+    with pytest.raises(ValueError, match="ya está registrado"):
+        _validate_duplicate_supplier_invoice(supplier_id="SUPLR-00001", supplier_invoice_no="FAC-2026-001")
+
+    # Creating a duplicate for DIFFERENT supplier should NOT fail
+    _validate_duplicate_supplier_invoice(supplier_id="SUPLR-00002", supplier_invoice_no="FAC-2026-001")
+
+    # Case 2: Submitting/approving first invoice (updates docstatus to 1)
+    invoice1.docstatus = 1
+    database.session.commit()
+
+    # Attempting to insert a duplicate must still fail
+    with pytest.raises(ValueError, match="ya está registrado"):
+        _validate_duplicate_supplier_invoice(supplier_id="SUPLR-00001", supplier_invoice_no="FAC-2026-001")
+
+    # Creating a new second invoice with the same supplier & different invoice number
+    invoice2 = PurchaseInvoice(
+        id="INV-002",
+        supplier_id="SUPLR-00001",
+        company="cacao",
+        supplier_invoice_no="FAC-2026-002",
+        docstatus=0,
+    )
+    database.session.add(invoice2)
+    database.session.commit()
+
+    # Editing second invoice to have duplicate number of invoice1 should fail
+    with pytest.raises(ValueError, match="ya está registrado"):
+        _validate_duplicate_supplier_invoice(
+            supplier_id="SUPLR-00001",
+            supplier_invoice_no="FAC-2026-001",
+            exclude_id=invoice2.id,
+        )
+
+    # Editing second invoice but keeping its own number (FAC-2026-002) should NOT fail
+    _validate_duplicate_supplier_invoice(
+        supplier_id="SUPLR-00001",
+        supplier_invoice_no="FAC-2026-002",
+        exclude_id=invoice2.id,
+    )
+
+    # Submitting/approving second invoice with duplicate number should fail
+    # Let's set its invoice number to FAC-2026-001 (simulating direct mutation without validation on save)
+    invoice2.supplier_invoice_no = "FAC-2026-001"
+    database.session.commit()
+    with pytest.raises(ValueError, match="ya está registrado"):
+        _validate_duplicate_supplier_invoice(
+            supplier_id="SUPLR-00001",
+            supplier_invoice_no="FAC-2026-001",
+            exclude_id=invoice2.id,
+        )
+
+    # Revert invoice2's number to free up FAC-2026-001
+    invoice2.supplier_invoice_no = "FAC-2026-002"
+    database.session.commit()
+
+    # Case 3: Cancel invoice1 (docstatus=2)
+    invoice1.docstatus = 2
+    database.session.commit()
+
+    # Now we can use "FAC-2026-001" since the other is cancelled
+    _validate_duplicate_supplier_invoice(supplier_id="SUPLR-00001", supplier_invoice_no="FAC-2026-001")
+    _validate_duplicate_supplier_invoice(
+        supplier_id="SUPLR-00001",
+        supplier_invoice_no="FAC-2026-001",
+        exclude_id=invoice2.id,
+    )


### PR DESCRIPTION
Add checks during purchase invoice creation, editing, and submission to ensure that the physical supplier invoice number is unique across all active (docstatus != 2) invoices for the same supplier. This eliminates risks of double payments and dual accounting entries. Comprehensive unit tests are added to test creation, edits, submission, and ignore cancelled invoices or different suppliers.

---
*PR created automatically by Jules for task [7239447657746191458](https://jules.google.com/task/7239447657746191458) started by @williamjmorenor*