### PR TITLE
Invalidate JWT token and clear session on logout

### DIFF
--- a/cacao_accounting/auth/__init__.py
+++ b/cacao_accounting/auth/__init__.py
@@ -11,7 +11,7 @@ from typing import Any
 # Librerias de terceros
 # ---------------------------------------------------------------------------------------
 from argon2 import PasswordHasher
-from flask import Blueprint, flash, redirect, render_template, request, url_for
+from flask import Blueprint, flash, redirect, render_template, request, session, url_for
 from flask.typing import ResponseReturnValue
 from flask_login import LoginManager, current_user, login_required, login_user, logout_user
 
@@ -98,7 +98,10 @@ def inicio_sesion():  # pragma: no cover
 @login.route("/salir")
 def cerrar_sesion():  # pragma: no cover
     """Finaliza la sesion actual."""
+    if current_user and current_user.is_authenticated:
+        current_user.token = None
     logout_user()
+    session.clear()
     return INICIO_SESION
 
 

--- a/tests/test_03webactions.py
+++ b/tests/test_03webactions.py
@@ -1468,3 +1468,31 @@ def test_accounting_module_badges_are_semantic_for_admin(request):
                 assert response.status_code == 200
                 assert 'data-status="ok"' in exchange_rates_row
                 assert "ca-status-warning" not in exchange_rates_row
+
+
+def test_logout_invalidates_session_and_token(request):
+    if request.config.getoption("--slow") == "True":
+        with app.app_context():
+            from flask_login import current_user
+            with app.test_client() as client:
+                # Login first
+                response = client.post("/login", data={"usuario": "cacao", "acceso": "cacao"})
+                assert response.status_code == 302
+
+                # Verify we are logged in and session is set
+                with client.session_transaction() as sess:
+                    assert sess.get("_user_id") is not None
+
+                assert current_user.is_authenticated
+                assert current_user.token is not None
+                old_user = current_user._get_current_object()
+
+                # Invalidate session/token by logging out
+                logout_response = client.get("/logout")
+                assert logout_response.status_code == 302
+
+                # Verify that the session is cleared
+                with client.session_transaction() as sess:
+                    assert sess.get("_user_id") is None
+
+                assert old_user.token is None


### PR DESCRIPTION
When logging out via /logout, /exit, or /salir, the application now sets current_user.token to None (if authenticated) and clears the Flask session container via session.clear(). A unit test has been added to tests/test_03webactions.py to ensure this invalidation operates properly without regressions.

---
*PR created automatically by Jules for task [14502193017989121381](https://jules.google.com/task/14502193017989121381) started by @williamjmorenor*