### PR TITLE
Add standard iat, nbf, and exp claims to auth JWT

### DIFF
--- a/cacao_accounting/auth/helpers.py
+++ b/cacao_accounting/auth/helpers.py
@@ -72,8 +72,17 @@ def puede_iniciar_en_escritorio(identidad: User) -> bool:
 def asignar_token_para_usuario(identidad: User) -> None:
     """Genera y asigna el token de autenticación para la API REST."""
     try:
+        from datetime import datetime, timedelta, timezone
+
+        ahora = datetime.now(timezone.utc)
+        payload = {
+            "user_id": identidad.id,
+            "iat": ahora,
+            "nbf": ahora,
+            "exp": ahora + timedelta(hours=8),
+        }
         identidad.token = encode(
-            {"user_id": identidad.id},
+            payload,
             current_app.config["SECRET_KEY"],
             algorithm="HS256",
         )

--- a/tests/test_auth_jwt.py
+++ b/tests/test_auth_jwt.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 William José Moreno Reyes
+
+from datetime import datetime, timedelta, timezone
+import pytest
+import jwt
+from cacao_accounting import create_app
+from cacao_accounting.database import User
+from cacao_accounting.auth.helpers import asignar_token_para_usuario
+
+
+def test_asignar_token_para_usuario():
+    app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:", "SECRET_KEY": "test-secret-key"})
+    with app.app_context():
+        # Create a mock user
+        user = User()
+        user.id = "user-123"
+        user.token = None
+
+        asignar_token_para_usuario(user)
+
+        assert user.token is not None
+
+        # Decode the token and verify the claims
+        payload = jwt.decode(user.token, "test-secret-key", algorithms=["HS256"])
+        assert payload["user_id"] == "user-123"
+        assert "iat" in payload
+        assert "nbf" in payload
+        assert "exp" in payload
+
+        # Check that 'exp' is after 'iat' by 8 hours
+        iat_time = datetime.fromtimestamp(payload["iat"], tz=timezone.utc)
+        exp_time = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+        nbf_time = datetime.fromtimestamp(payload["nbf"], tz=timezone.utc)
+
+        assert exp_time == iat_time + timedelta(hours=8)
+        assert nbf_time == iat_time
+
+
+def test_jwt_expiration_validation():
+    app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:", "SECRET_KEY": "test-secret-key"})
+    with app.app_context():
+        # Construct an expired token
+        ahora = datetime.now(timezone.utc)
+        expired_payload = {
+            "user_id": "user-expired",
+            "iat": ahora - timedelta(hours=9),
+            "nbf": ahora - timedelta(hours=9),
+            "exp": ahora - timedelta(hours=1),
+        }
+        expired_token = jwt.encode(expired_payload, "test-secret-key", algorithm="HS256")
+
+        # PyJWT should raise ExpiredSignatureError when decoding an expired token
+        with pytest.raises(jwt.ExpiredSignatureError):
+            jwt.decode(expired_token, "test-secret-key", algorithms=["HS256"])


### PR DESCRIPTION
This PR resolves a Medium-severity security risk (CWE-613: Insufficient Session Expiration). Previously, the auth helper function `asignar_token_para_usuario` generated JWT tokens containing only the `user_id` claim, making them valid forever.

To fix this:
1. Updated `asignar_token_para_usuario` in `cacao_accounting/auth/helpers.py` to include `iat`, `nbf`, and `exp` claims with an expiration period of 8 hours.
2. Created a new unit test suite in `tests/test_auth_jwt.py` to verify that JWT tokens are generated with correct claims, expiration durations, and that PyJWT raises `ExpiredSignatureError` correctly when the token has expired.
3. Verified all tests passed successfully.

---
*PR created automatically by Jules for task [4097449355444793971](https://jules.google.com/task/4097449355444793971) started by @williamjmorenor*