### PR TITLE
Mitigate Open Redirect via request.referrer (SEC-003)

### DIFF
--- a/ESTADO_ACTUAL.md
+++ b/ESTADO_ACTUAL.md
@@ -1,4 +1,9 @@
-# Estado Actual del Proyecto - 2026-07-10
+# Estado Actual del Proyecto - 2026-07-11
+
+- **Mitigación de Redirección Abierta (SEC-003 — 2026-07-11):** Se corrigió la vulnerabilidad de Open Redirect en redirecciones de comentarios y tareas.
+  - Se validó `request.referrer` antes de la redirección en los endpoints `/api/documents/<document_type>/<document_id>/comments` y `/api/documents/<document_type>/<document_id>/tasks`.
+  - La redirección solo se ejecuta para URL relativas o con el mismo origen de la aplicación (`request.host`), cayendo a `url_for("cacao_app.pagina_inicio")` en caso de referrers externos.
+  - Se agregaron pruebas exhaustivas que validan la protección.
 
 - **Auditoría Senior DBA — Commits 4-10 (2026-07-10):** Se completaron mejoras de integridad de datos en los modelos SQLAlchemy.
   - **Commit 4 (`10a2bc1`):** 6 UniqueConstraints nuevas (User.user, FiscalYear, NamingSeries, Workflow, WorkflowState, WorkflowTransition) + bug fix en Roles.note + 4 redundantes eliminadas.

--- a/PENDIENTE.md
+++ b/PENDIENTE.md
@@ -17,6 +17,7 @@
 - [ ] Ampliar cobertura de pruebas funcionales por documento del MVP fiscal (casos positivos/negativos por doctype).
 
 ## Administracion y Seguridad
+- [x] Mitigar vulnerabilidad SEC-003 de Redirección Abierta (Open Redirect) vía request.referrer.
 - [ ] Activar `AuditLog` automatico para cambios en documentos operativos.
 
 ## Multi-Ledger y Revalorizacion

--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -1,5 +1,15 @@
 # SESSIONS - Historical Decisions & Milestones
 
+## 2026-07-11 : Mitigación de Redirección Abierta (Open Redirect) vía request.referrer (SEC-003, CWE-601)
+- **Petición del usuario:** En `api/__init__.py:180-181,194-195` se usa `request.referrer` sin validación para redirecciones POST de comentarios y tareas creados desde formularios. Esto posibilita ataques de redirección abierta (CWE-601).
+- **Implementación:**
+  - Se importó `urlparse` desde `urllib.parse` y `url_for` en `cacao_accounting/api/__init__.py`.
+  - Se modificaron los endpoints de creación de comentarios (`/api/documents/<document_type>/<document_id>/comments`) y tareas (`/api/documents/<document_type>/<document_id>/tasks`) para validar el referrer antes de redirigir.
+  - La redirección solo se ejecuta si el referrer es seguro, es decir, si es una URL relativa (`netloc == ""`) o si el host coincide con el de la aplicación (`netloc == request.host`).
+  - Si el referrer es externo o no confiable, se realiza una redirección segura a la página de inicio (`url_for("cacao_app.pagina_inicio")`).
+  - Se agregaron pruebas automatizadas exhaustivas en `tests/test_desktop_cloud_mode.py` (`test_cloud_collaboration_open_redirect_protection`) para verificar que referer seguro redirige correctamente y referer inseguro redirige a `/index`.
+- **Validación:** Todas las pruebas pasaron satisfactoriamente y no hay regresiones.
+
 ## 2026-07-10 : Implementación de Límite de Intentos de Inicio de Sesión y Rate Limiting en API (CWE-307)
 - **Petición del usuario:** No hay límite de intentos de inicio de sesión ni rate limiting en endpoints de la API, lo que posibilita ataques de fuerza bruta (CWE-307). Se sugiere usar `Flask-Limiter` con Redis para modo nube, pero de manera completamente opcional para respetar el modo escritorio como ciudadano de primer nivel. Adicionalmente se solicita proveer un archivo `docker-compose.yml` que defina tres servicios (`app`, `db`, `cache`).
 - **Implementación:**

--- a/cacao_accounting/api/__init__.py
+++ b/cacao_accounting/api/__init__.py
@@ -8,11 +8,12 @@
 # --------------------------------------------------------------------------------------
 from functools import wraps
 from typing import Any, cast
+from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------------------
 # Librerias de terceros
 # ---------------------------------------------------------------------------------------
-from flask import Blueprint, abort, current_app, jsonify, redirect, render_template, request
+from flask import Blueprint, abort, current_app, jsonify, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 from jwt import decode
 
@@ -183,7 +184,10 @@ def api_document_comment(document_type: str, document_id: str):
     except CollaborationError as exc:
         abort_for_collaboration_error(exc)
     if request.form and request.referrer:
-        return redirect(request.referrer)
+        parsed = urlparse(request.referrer)
+        if parsed.netloc == "" or parsed.netloc == request.host:
+            return redirect(request.referrer)
+        return redirect(url_for("cacao_app.pagina_inicio"))
     return jsonify({"id": entry.id, "action": entry.action}), 201
 
 
@@ -197,7 +201,10 @@ def api_document_task(document_type: str, document_id: str):
     except CollaborationError as exc:
         abort_for_collaboration_error(exc)
     if request.form and request.referrer:
-        return redirect(request.referrer)
+        parsed = urlparse(request.referrer)
+        if parsed.netloc == "" or parsed.netloc == request.host:
+            return redirect(request.referrer)
+        return redirect(url_for("cacao_app.pagina_inicio"))
     return jsonify({"id": task.id, "status": task.status}), 201
 
 

--- a/tests/test_desktop_cloud_mode.py
+++ b/tests/test_desktop_cloud_mode.py
@@ -199,3 +199,66 @@ def test_cloud_comment_and_task_flow_records_audit_trail(app_ctx) -> None:
     assert "task_status_changed" in actions
     assert "task_completed" in actions
     assert "task_cancelled" in actions
+
+
+def test_cloud_collaboration_open_redirect_protection(app_ctx) -> None:
+    """Comments and tasks redirect to referrer safely, avoiding Open Redirect."""
+    client = app_ctx.test_client()
+    _login(client)
+
+    # 1. Safe relative referrer should be accepted
+    response = client.post(
+        "/api/documents/journal_entry/journal-id/comments",
+        data={"comment": "Safe comment"},
+        headers={"Referer": "/safe-relative-path"},
+    )
+    assert response.status_code == 302
+    assert response.location in ("/safe-relative-path", "http://localhost/safe-relative-path")
+
+    # 2. Safe same-host referrer should be accepted
+    response = client.post(
+        "/api/documents/journal_entry/journal-id/comments",
+        data={"comment": "Safe comment"},
+        headers={"Referer": "http://localhost/another-safe-path"},
+    )
+    assert response.status_code == 302
+    assert response.location == "http://localhost/another-safe-path"
+
+    # 3. Unsafe external referrer should be redirected to home page
+    response = client.post(
+        "/api/documents/journal_entry/journal-id/comments",
+        data={"comment": "Safe comment"},
+        headers={"Referer": "https://malicious.com/phishing"},
+    )
+    assert response.status_code == 302
+    assert response.location in ("/index", "http://localhost/index")
+
+    # 4. Safe relative referrer for tasks
+    response = client.post(
+        "/api/documents/journal_entry/journal-id/tasks",
+        data={
+            "title": "Validate task",
+            "description": "Task desc",
+            "assigned_to": "admin-id",
+            "priority": "high",
+            "due_date": "2026-05-31",
+        },
+        headers={"Referer": "/safe-task-path"},
+    )
+    assert response.status_code == 302
+    assert response.location in ("/safe-task-path", "http://localhost/safe-task-path")
+
+    # 5. Unsafe external referrer for tasks should be redirected to home page
+    response = client.post(
+        "/api/documents/journal_entry/journal-id/tasks",
+        data={
+            "title": "Validate task",
+            "description": "Task desc",
+            "assigned_to": "admin-id",
+            "priority": "high",
+            "due_date": "2026-05-31",
+        },
+        headers={"Referer": "https://evil.com/phishing"},
+    )
+    assert response.status_code == 302
+    assert response.location in ("/index", "http://localhost/index")


### PR DESCRIPTION
This PR addresses SEC-003 [ALTA] Open Redirect via request.referrer in the comment and task endpoints. It validates request.referrer using urlparse, allowing redirects only to relative URLs or same-origin URLs (matching request.host), and falling back safely to the homepage. Extended unit tests ensure safe redirects are allowed and external ones are blocked. All quality checks (black, ruff, flake8, mypy, pytest) are fully passing.

---
*PR created automatically by Jules for task [15005281241069132739](https://jules.google.com/task/15005281241069132739) started by @williamjmorenor*