### PR TITLE
fix(sec): SEC-007 Escaping Jinja2 variables inside <script> without JS escaping

### DIFF
--- a/cacao_accounting/app/templates/app.html
+++ b/cacao_accounting/app/templates/app.html
@@ -117,30 +117,30 @@
 <script src="{{ url_for('static', filename='node_modules/chart.js/dist/chart.umd.js') }}"></script>
 <script>
   globalThis.dashboardConfig = {
-    initialCompany: '{{ entidades[0].id if entidades else "" }}',
-    periods: {{ dashboard_periods | tojson | safe }},
-    companies: {{ dashboard_entities | tojson | safe }},
+    initialCompany: {{ (entidades[0].id if entidades else "") | tojson }},
+    periods: {{ dashboard_periods | tojson }},
+    companies: {{ dashboard_entities | tojson }},
     messages: {
-      dashboardLoadError: '{{ _("No se pudo cargar el dashboard.") }}'
+      dashboardLoadError: {{ _("No se pudo cargar el dashboard.") | tojson }}
     },
     titles: {
-      accounting: '{{ _("Resumen financiero") }}',
-      banks: '{{ _("Saldos bancarios") }}',
-      purchases: '{{ _("Facturas por pagar") }}',
-      inventory: '{{ _("Menor existencia") }}',
-      sales: '{{ _("Mejores clientes") }}'
+      accounting: {{ _("Resumen financiero") | tojson }},
+      banks: {{ _("Saldos bancarios") | tojson }},
+      purchases: {{ _("Facturas por pagar") | tojson }},
+      inventory: {{ _("Menor existencia") | tojson }},
+      sales: {{ _("Mejores clientes") | tojson }}
     },
     headings: {
-      accounting: ['{{ _("Concepto") }}', '{{ _("Valor") }}'],
-      banks: ['{{ _("Cuenta") }}', '{{ _("Saldo") }}'],
-      purchases: ['{{ _("Factura") }}', '{{ _("Proveedor") }}', '{{ _("Pendiente") }}'],
-      inventory: ['{{ _("Ítem") }}', '{{ _("Bodega") }}', '{{ _("Existencia") }}'],
-      sales: ['{{ _("Cliente") }}', '{{ _("Total") }}']
+      accounting: [{{ _("Concepto") | tojson }}, {{ _("Valor") | tojson }}],
+      banks: [{{ _("Cuenta") | tojson }}, {{ _("Saldo") | tojson }}],
+      purchases: [{{ _("Factura") | tojson }}, {{ _("Proveedor") | tojson }}, {{ _("Pendiente") | tojson }}],
+      inventory: [{{ _("Ítem") | tojson }}, {{ _("Bodega") | tojson }}, {{ _("Existencia") | tojson }}],
+      sales: [{{ _("Cliente") | tojson }}, {{ _("Total") | tojson }}]
     },
     chartLabels: {
-      income: '{{ _("Ingresos") }}',
-      expense: '{{ _("Gastos") }}',
-      sales: '{{ _("Ventas") }}'
+      income: {{ _("Ingresos") | tojson }},
+      expense: {{ _("Gastos") | tojson }},
+      sales: {{ _("Ventas") | tojson }}
     },
     monthNames: ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic']
   };

--- a/cacao_accounting/compras/templates/compras/cotizacion_proveedor_nueva.html
+++ b/cacao_accounting/compras/templates/compras/cotizacion_proveedor_nueva.html
@@ -21,7 +21,7 @@
   </ol>
 </nav>
 
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {{ tf_macros.transaction_form_header("Editar Cotización de Proveedor" if edit else "Cotización de Proveedor", cancel_url=url_for('compras.compras_cotizacion_proveedor_lista')) }}
   <div class="ca-card p-3 mb-3">

--- a/cacao_accounting/compras/templates/compras/factura_compra_nuevo.html
+++ b/cacao_accounting/compras/templates/compras/factura_compra_nuevo.html
@@ -22,7 +22,7 @@
   </ol>
 </nav>
 
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {% if from_order_id %}<input type="hidden" name="from_order" value="{{ from_order_id }}">{% endif %}
   {% if from_receipt_id %}<input type="hidden" name="from_receipt" value="{{ from_receipt_id }}">{% endif %}

--- a/cacao_accounting/compras/templates/compras/orden_compra_nuevo.html
+++ b/cacao_accounting/compras/templates/compras/orden_compra_nuevo.html
@@ -14,7 +14,7 @@
       {{ (registro.document_no or registro.id) if edit else 'Nueva Orden' }}</li>
   </ol>
 </nav>
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {% if from_request_id %}<input type="hidden" name="from_request" value="{{ from_request_id }}">{% endif %}
   {% if from_rfq_id %}<input type="hidden" name="from_rfq" value="{{ from_rfq_id }}">{% endif %}

--- a/cacao_accounting/compras/templates/compras/recepcion_nuevo.html
+++ b/cacao_accounting/compras/templates/compras/recepcion_nuevo.html
@@ -21,7 +21,7 @@
   </ol>
 </nav>
 
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {% if from_order_id %}<input type="hidden" name="from_order" value="{{ from_order_id }}">{% endif %}
   {{ tf_macros.transaction_form_header("Editar Recepción de Compra" if edit else "Recepción de Compra", cancel_url=url_for('compras.compras_recepcion_lista')) }}

--- a/cacao_accounting/compras/templates/compras/solicitud_compra_nueva.html
+++ b/cacao_accounting/compras/templates/compras/solicitud_compra_nueva.html
@@ -10,7 +10,7 @@
     <li class="breadcrumb-item active" aria-current="page">{% if edit %}{{ registro.document_no or registro.id }}{% else %}Nueva Solicitud{% endif %}</li>
   </ol>
 </nav>
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {{ tf_macros.transaction_form_header("Editar Solicitud de Compra" if edit else "Solicitud de Compra") }}
   <div class="ca-card p-3 mb-3">

--- a/cacao_accounting/compras/templates/compras/solicitud_cotizacion_nuevo.html
+++ b/cacao_accounting/compras/templates/compras/solicitud_cotizacion_nuevo.html
@@ -21,7 +21,7 @@
   </ol>
 </nav>
 
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {% if from_request_id %}<input type="hidden" name="from_request" value="{{ from_request_id }}">{% endif %}
   {% set title = "Solicitud de Cotización" ~ ((" desde " ~ (solicitud_origen.document_no or solicitud_origen.id)) if solicitud_origen else "") %}

--- a/cacao_accounting/contabilidad/templates/contabilidad/journal.html
+++ b/cacao_accounting/contabilidad/templates/contabilidad/journal.html
@@ -436,7 +436,7 @@
             document.getElementById('line-reference2').textContent = readValue(data.reference2);
             document.getElementById('line-debit').textContent = data.debit || '0.00';
             document.getElementById('line-credit').textContent = data.credit || '0.00';
-            document.getElementById('line-advance').textContent = data.advance === '1' ? '{{ _('Sí') }}' : '{{ _('No') }}';
+            document.getElementById('line-advance').textContent = data.advance === '1' ? {{ _('Sí') | tojson }} : {{ _('No') | tojson }};
             document.getElementById('line-memo').textContent = readValue(data.memo);
 
             document.getElementById('modal-line-order').textContent = data.order || '-';
@@ -452,7 +452,7 @@
             document.getElementById('modal-line-reference2').textContent = readValue(data.reference2);
             document.getElementById('modal-line-debit').textContent = data.debit || '0.00';
             document.getElementById('modal-line-credit').textContent = data.credit || '0.00';
-            document.getElementById('modal-line-advance').textContent = data.advance === '1' ? '{{ _('Sí') }}' : '{{ _('No') }}';
+            document.getElementById('modal-line-advance').textContent = data.advance === '1' ? {{ _('Sí') | tojson }} : {{ _('No') | tojson }};
             document.getElementById('modal-line-memo').textContent = readValue(data.memo);
         }
 
@@ -482,19 +482,19 @@
     (function () {
         var reversalDateInput = document.getElementById('reversal_date');
         var guidance = document.getElementById('reversal-period-guidance');
-        var originalPostingDate = '{{ registro.date.isoformat() if registro.date else '' }}';
+        var originalPostingDate = {{ (registro.date.isoformat() if registro.date else "") | tojson }};
         if (!reversalDateInput || !guidance || !originalPostingDate) return;
 
         function updateReversalGuidance() {
             var selectedDate = reversalDateInput.value || '';
             if (!selectedDate) {
-                guidance.textContent = '{{ _('Seleccione una fecha en otro período contable para generar el borrador de reversión con la misma serie.') }}';
+                guidance.textContent = {{ _('Seleccione una fecha en otro período contable para generar el borrador de reversión con la misma serie.') | tojson }};
                 return;
             }
             var samePeriod = selectedDate.slice(0, 7) === originalPostingDate.slice(0, 7);
             guidance.textContent = samePeriod
-                ? '{{ _('La fecha elegida cae en el mismo período. Debe usar una fecha de otro período para revertir este comprobante.') }}'
-                : '{{ _('La fecha elegida cae en un período distinto. Se puede crear el borrador de reversión para el nuevo período contable.') }}';
+                ? {{ _('La fecha elegida cae en el mismo período. Debe usar una fecha de otro período para revertir este comprobante.') | tojson }}
+                : {{ _('La fecha elegida cae en un período distinto. Se puede crear el borrador de reversión para el nuevo período contable.') | tojson }};
         }
 
         reversalDateInput.addEventListener('input', updateReversalGuidance);

--- a/cacao_accounting/contabilidad/templates/contabilidad/journal_nuevo.html
+++ b/cacao_accounting/contabilidad/templates/contabilidad/journal_nuevo.html
@@ -710,7 +710,7 @@
   },
 } %}
 
-<form class="ca-journal-form" method="post" x-data='journalEntryForm({{ journal_initial_state | tojson | safe }})'
+<form class="ca-journal-form" method="post" x-data='journalEntryForm({{ journal_initial_state | tojson }})'
   @submit="prepareSubmit" action="{{ submit_url }}">
   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <input type="hidden" name="journal_payload" :value="payload">

--- a/cacao_accounting/contabilidad/templates/contabilidad/recurring_journal_nuevo.html
+++ b/cacao_accounting/contabilidad/templates/contabilidad/recurring_journal_nuevo.html
@@ -152,7 +152,7 @@
   };
 </script>
 
-<form class="ca-journal-form" method="post" x-data='recurringJournalForm({ initialJournal: {{ (initial_journal or {}) | tojson | safe }} })' @submit="prepareSubmit" action="{{ submit_url }}">
+<form class="ca-journal-form" method="post" x-data='recurringJournalForm({ initialJournal: {{ (initial_journal or {}) | tojson }} })' @submit="prepareSubmit" action="{{ submit_url }}">
   {{ form.csrf_token }}
   <input type="hidden" name="items_json" :value="payload">
   <input type="hidden" name="ledger_id" :value="primarySelectedBook">

--- a/cacao_accounting/inventario/templates/inventario/entrada_nuevo.html
+++ b/cacao_accounting/inventario/templates/inventario/entrada_nuevo.html
@@ -15,7 +15,7 @@
       {{ (registro.document_no or registro.id) if edit else _('Nuevo Movimiento') }}</li>
   </ol>
 </nav>
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {{ tf_macros.transaction_form_header("Editar Movimiento de Inventario" if edit else "Movimiento de Inventario") }}
   <div class="ca-card p-3 mb-3">

--- a/cacao_accounting/templates/transaction_form_macros.html
+++ b/cacao_accounting/templates/transaction_form_macros.html
@@ -1,13 +1,13 @@
 {% macro transaction_form_js(config) %}
 <script>
-  globalThis.transactionFormConfig = {{ config | tojson | safe }};
+  globalThis.transactionFormConfig = {{ config | tojson }};
 </script>
 {% endmacro %}
 
 {% macro smart_select(doctype, name, label, initial_value='', initial_label='', filters={}, filter_sources=[], required=False, min_chars=1, preload=False, required_filters=[], auto_select_default=False, load_on_filter_change=False, x_model=None, on_select=None, initial_value_expr=None, initial_label_expr=None) %}
 <div class="ca-smart-select" x-data='smartSelect({
-    doctype: "{{ doctype }}",
-    name: "{{ name }}",
+    doctype: {{ doctype | tojson }},
+    name: {{ name | tojson }},
     minChars: {{ min_chars }},
     preload: {{ "true" if preload else "false" }},
     loadOnFilterChange: {{ "true" if load_on_filter_change else "false" }},

--- a/cacao_accounting/ventas/templates/ventas/cotizacion_nuevo.html
+++ b/cacao_accounting/ventas/templates/ventas/cotizacion_nuevo.html
@@ -21,7 +21,7 @@
   </ol>
 </nav>
 
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {% if from_request_id %}
   <input type="hidden" name="from_request" value="{{ from_request_id }}">

--- a/cacao_accounting/ventas/templates/ventas/entrega_nuevo.html
+++ b/cacao_accounting/ventas/templates/ventas/entrega_nuevo.html
@@ -21,7 +21,7 @@
   </ol>
 </nav>
 
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {% if from_order_id %}<input type="hidden" name="from_order" value="{{ from_order_id }}">{% endif %}
   {{ tf_macros.transaction_form_header("Editar Nota de Entrega" if edit else "Nota de Entrega", cancel_url=url_for('ventas.ventas_entrega_lista')) }}

--- a/cacao_accounting/ventas/templates/ventas/factura_venta_nuevo.html
+++ b/cacao_accounting/ventas/templates/ventas/factura_venta_nuevo.html
@@ -21,7 +21,7 @@
   </ol>
 </nav>
 
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {% if from_order_id %}<input type="hidden" name="from_order" value="{{ from_order_id }}">{% endif %}
   {% if from_note_id %}<input type="hidden" name="from_note" value="{{ from_note_id }}">{% endif %}

--- a/cacao_accounting/ventas/templates/ventas/orden_venta_nuevo.html
+++ b/cacao_accounting/ventas/templates/ventas/orden_venta_nuevo.html
@@ -21,7 +21,7 @@
   </ol>
 </nav>
 
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {% if from_request_id %}
   <input type="hidden" name="from_request" value="{{ from_request_id }}">

--- a/cacao_accounting/ventas/templates/ventas/solicitud_venta_nuevo.html
+++ b/cacao_accounting/ventas/templates/ventas/solicitud_venta_nuevo.html
@@ -11,7 +11,7 @@
       {{ (registro.document_no or registro.id) if edit else _('Nuevo Pedido') }}</li>
   </ol>
 </nav>
-<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson | safe }})'>
+<form method="post" id="form-main" x-data='transactionForm({{ transaction_config | tojson }})'>
   {{ form.csrf_token }}
   {{ tf_macros.transaction_form_header("Editar Pedido de Venta" if edit else "Pedido de Venta") }}
   <div class="ca-card p-3 mb-3">


### PR DESCRIPTION
This pull request addresses SEC-007 by properly escaping Jinja2 variables interpolated within <script> tags and x-data attributes across all HTML templates.

Key changes:
1. Replaced raw quote-wrapped strings in `app.html`, `journal.html`, and `transaction_form_macros.html` with secure `|tojson` serialization.
2. Removed redundant `|safe` filters following `|tojson` inside script blocks and HTML attributes across 14 template files to satisfy security scanners and align with modern Flask/Jinja2 security standards.
3. Successfully ran and verified all 1285 unit tests to ensure zero regressions.

---
*PR created automatically by Jules for task [4295530221163159468](https://jules.google.com/task/4295530221163159468) started by @williamjmorenor*