### PR TITLE
Global Timezone Configuration in Setup Regional Wizard

### DIFF
--- a/cacao_accounting/__init__.py
+++ b/cacao_accounting/__init__.py
@@ -62,8 +62,10 @@ from cacao_accounting.runtime_mode import force_single_entity, is_cloud_mode, is
 from cacao_accounting.setup import setup_ as setup_wizard
 from cacao_accounting.ventas import ventas
 from cacao_accounting.version import PRERELEASE
+from flask_babel import Babel
 
 alembic = Alembic()
+babel = Babel()
 
 
 def command() -> None:  # pragma: no cover
@@ -79,12 +81,32 @@ def iniciar_extenciones(app: Flask | None = None) -> None:
         from flask_wtf.csrf import CSRFProtect
         from cacao_accounting.limiter import init_limiter
         from cacao_accounting.cache import init_cache
+        from flask import has_app_context, has_request_context
+
+        def get_locale():
+            if not (has_app_context() or has_request_context()):
+                return "es"
+            try:
+                from cacao_accounting.setup.service import get_setup_value, SETUP_LANGUAGE
+                return get_setup_value(SETUP_LANGUAGE, "es")
+            except Exception:
+                return "es"
+
+        def get_timezone():
+            if not (has_app_context() or has_request_context()):
+                return "America/Managua"
+            try:
+                from cacao_accounting.setup.service import get_setup_value, SETUP_TIMEZONE
+                return get_setup_value(SETUP_TIMEZONE, "America/Managua")
+            except Exception:
+                return "America/Managua"
 
         csrf = CSRFProtect()
         csrf.init_app(app)
         # alembic.init_app(app)
         database.init_app(app)
         administrador_sesion.init_app(app)
+        babel.init_app(app, locale_selector=get_locale, timezone_selector=get_timezone)
         init_cache(app)
         init_limiter(app)
     else:

--- a/cacao_accounting/setup/__init__.py
+++ b/cacao_accounting/setup/__init__.py
@@ -104,7 +104,7 @@ def _handle_setup_regional_step() -> object | None:
     form = SetupRegionalForm(language=setup_data.get("idioma"), currencies=available_currencies())
     if form.validate_on_submit():
         try:
-            save_regional_settings(form.pais.data, form.moneda.data)
+            save_regional_settings(form.pais.data, form.moneda.data, form.zona_horaria.data)
         except ValueError as exc:
             flash(texts["invalid_currency"] if str(exc) else texts["invalid_regional"], "danger")
             return None
@@ -162,7 +162,11 @@ def _setup_form(step: int, setup_data: dict[str, str]) -> SetupLanguageForm | Se
         return SetupLanguageForm(data={"idioma": setup_data.get("idioma")})
     if step == 2:
         return SetupRegionalForm(
-            data={"pais": setup_data.get("pais"), "moneda": setup_data.get("moneda")},
+            data={
+                "pais": setup_data.get("pais"),
+                "moneda": setup_data.get("moneda"),
+                "zona_horaria": setup_data.get("zona_horaria"),
+            },
             language=setup_data.get("idioma"),
             currencies=available_currencies(),
         )

--- a/cacao_accounting/setup/catalogs.py
+++ b/cacao_accounting/setup/catalogs.py
@@ -55,44 +55,45 @@ class CountryOption:
     name_es: str
     name_en: str
     currency: str
+    timezone: str
 
 
 AMERICA_COUNTRIES = (
-    CountryOption("AG", "Antigua y Barbuda", "Antigua and Barbuda", "XCD"),
-    CountryOption("AR", "Argentina", "Argentina", "ARS"),
-    CountryOption("BS", "Bahamas", "Bahamas", "BSD"),
-    CountryOption("BB", "Barbados", "Barbados", "BBD"),
-    CountryOption("BZ", "Belice", "Belize", "BZD"),
-    CountryOption("BO", "Bolivia", "Bolivia", "BOB"),
-    CountryOption("BR", "Brasil", "Brazil", "BRL"),
-    CountryOption("CA", "Canadá", "Canada", "CAD"),
-    CountryOption("CL", "Chile", "Chile", "CLP"),
-    CountryOption("CO", "Colombia", "Colombia", "COP"),
-    CountryOption("CR", "Costa Rica", "Costa Rica", "CRC"),
-    CountryOption("CU", "Cuba", "Cuba", "CUP"),
-    CountryOption("DM", "Dominica", "Dominica", "XCD"),
-    CountryOption("DO", "República Dominicana", "Dominican Republic", "DOP"),
-    CountryOption("EC", "Ecuador", "Ecuador", "USD"),
-    CountryOption("SV", "El Salvador", "El Salvador", "USD"),
-    CountryOption("US", "Estados Unidos", "United States", "USD"),
-    CountryOption("GD", "Granada", "Grenada", "XCD"),
-    CountryOption("GT", "Guatemala", "Guatemala", "GTQ"),
-    CountryOption("GY", "Guyana", "Guyana", "GYD"),
-    CountryOption("HT", "Haití", "Haiti", "HTG"),
-    CountryOption("HN", "Honduras", "Honduras", "HNL"),
-    CountryOption("JM", "Jamaica", "Jamaica", "JMD"),
-    CountryOption("MX", "México", "Mexico", "MXN"),
-    CountryOption("NI", "Nicaragua", "Nicaragua", "NIO"),
-    CountryOption("PA", "Panamá", "Panama", "PAB"),
-    CountryOption("PY", "Paraguay", "Paraguay", "PYG"),
-    CountryOption("PE", "Perú", "Peru", "PEN"),
-    CountryOption("KN", "San Cristóbal y Nieves", "Saint Kitts and Nevis", "XCD"),
-    CountryOption("LC", "Santa Lucía", "Saint Lucia", "XCD"),
-    CountryOption("VC", "San Vicente y las Granadinas", "Saint Vincent and the Grenadines", "XCD"),
-    CountryOption("SR", "Surinam", "Suriname", "SRD"),
-    CountryOption("TT", "Trinidad y Tobago", "Trinidad and Tobago", "TTD"),
-    CountryOption("UY", "Uruguay", "Uruguay", "UYU"),
-    CountryOption("VE", "Venezuela", "Venezuela", "VES"),
+    CountryOption("AG", "Antigua y Barbuda", "Antigua and Barbuda", "XCD", "America/Antigua"),
+    CountryOption("AR", "Argentina", "Argentina", "ARS", "America/Argentina/Buenos_Aires"),
+    CountryOption("BS", "Bahamas", "Bahamas", "BSD", "America/Nassau"),
+    CountryOption("BB", "Barbados", "Barbados", "BBD", "America/Barbados"),
+    CountryOption("BZ", "Belice", "Belize", "BZD", "America/Belize"),
+    CountryOption("BO", "Bolivia", "Bolivia", "BOB", "America/La_Paz"),
+    CountryOption("BR", "Brasil", "Brazil", "BRL", "America/Sao_Paulo"),
+    CountryOption("CA", "Canadá", "Canada", "CAD", "America/Toronto"),
+    CountryOption("CL", "Chile", "Chile", "CLP", "America/Santiago"),
+    CountryOption("CO", "Colombia", "Colombia", "COP", "America/Bogota"),
+    CountryOption("CR", "Costa Rica", "Costa Rica", "CRC", "America/Costa_Rica"),
+    CountryOption("CU", "Cuba", "Cuba", "CUP", "America/Havana"),
+    CountryOption("DM", "Dominica", "Dominica", "XCD", "America/Dominica"),
+    CountryOption("DO", "República Dominicana", "Dominican Republic", "DOP", "America/Santo_Domingo"),
+    CountryOption("EC", "Ecuador", "Ecuador", "USD", "America/Guayaquil"),
+    CountryOption("SV", "El Salvador", "El Salvador", "USD", "America/El_Salvador"),
+    CountryOption("US", "Estados Unidos", "United States", "USD", "America/New_York"),
+    CountryOption("GD", "Granada", "Grenada", "XCD", "America/Grenada"),
+    CountryOption("GT", "Guatemala", "Guatemala", "GTQ", "America/Guatemala"),
+    CountryOption("GY", "Guyana", "Guyana", "GYD", "America/Guyana"),
+    CountryOption("HT", "Haití", "Haiti", "HTG", "America/Port-au-Prince"),
+    CountryOption("HN", "Honduras", "Honduras", "HNL", "America/Tegucigalpa"),
+    CountryOption("JM", "Jamaica", "Jamaica", "JMD", "America/Jamaica"),
+    CountryOption("MX", "México", "Mexico", "MXN", "America/Mexico_City"),
+    CountryOption("NI", "Nicaragua", "Nicaragua", "NIO", "America/Managua"),
+    CountryOption("PA", "Panamá", "Panama", "PAB", "America/Panama"),
+    CountryOption("PY", "Paraguay", "Paraguay", "PYG", "America/Asuncion"),
+    CountryOption("PE", "Perú", "Peru", "PEN", "America/Lima"),
+    CountryOption("KN", "San Cristóbal y Nieves", "Saint Kitts and Nevis", "XCD", "America/St_Kitts"),
+    CountryOption("LC", "Santa Lucía", "Saint Lucia", "XCD", "America/St_Lucia"),
+    CountryOption("VC", "San Vicente y las Granadinas", "Saint Vincent and the Grenadines", "XCD", "America/St_Vincent"),
+    CountryOption("SR", "Surinam", "Suriname", "SRD", "America/Paramaribo"),
+    CountryOption("TT", "Trinidad y Tobago", "Trinidad and Tobago", "TTD", "America/Port_of_Spain"),
+    CountryOption("UY", "Uruguay", "Uruguay", "UYU", "America/Montevideo"),
+    CountryOption("VE", "Venezuela", "Venezuela", "VES", "America/Caracas"),
 )
 
 
@@ -112,6 +113,7 @@ SETUP_TEXTS: dict[str, dict[str, str]] = {
         "regional_help": "La moneda se sugiere según el país y solo se listan monedas disponibles en la base de datos.",
         "country": "País predeterminado",
         "currency": "Moneda predeterminada",
+        "timezone": "Zona horaria",
         "company_title": "Datos de empresa",
         "company_help": "Estos datos crean la compañía base, su libro contable y el período inicial.",
         "company_code": "Código de empresa",
@@ -156,6 +158,7 @@ SETUP_TEXTS: dict[str, dict[str, str]] = {
         "regional_help": "Currency is suggested by country and only database currencies are listed.",
         "country": "Default country",
         "currency": "Default currency",
+        "timezone": "Timezone",
         "company_title": "Company details",
         "company_help": "These details create the base company, accounting book, and initial period.",
         "company_code": "Company code",
@@ -209,6 +212,24 @@ def country_currency_map() -> dict[str, str]:
     return {country.code: country.currency for country in AMERICA_COUNTRIES}
 
 
+def country_timezone_map() -> dict[str, str]:
+    """Devuelve la zona horaria sugerida por país."""
+    return {country.code: country.timezone for country in AMERICA_COUNTRIES}
+
+
+def timezone_choices() -> list[tuple[str, str]]:
+    """Devuelve las opciones de zona horaria disponibles en zoneinfo."""
+    import zoneinfo
+    tzs = sorted(list(zoneinfo.available_timezones()))
+    choices = []
+    for tz in tzs:
+        if "/" in tz or tz == "UTC":
+            choices.append((tz, tz))
+    if not choices:
+        choices = [("UTC", "UTC")]
+    return choices
+
+
 def catalog_choices(language: str | None) -> list[tuple[str, str]]:
     """Devuelve opciones localizadas de catálogo contable."""
     texts = setup_texts(language)
@@ -223,5 +244,6 @@ def setup_template_context(language: str | None) -> dict[str, Any]:
     return {
         "texts": setup_texts(language),
         "country_currency_map": country_currency_map(),
+        "country_timezone_map": country_timezone_map(),
         "language": normalize_language(language),
     }

--- a/cacao_accounting/setup/forms.py
+++ b/cacao_accounting/setup/forms.py
@@ -36,6 +36,7 @@ class SetupRegionalForm(FlaskForm):
 
     pais = SelectField("País predeterminado", choices=COUNTRY_CHOICES, validators=[DataRequired()])
     moneda = SelectField("Moneda predeterminada", choices=[], validators=[DataRequired()])
+    zona_horaria = SelectField("Zona horaria", choices=[], validators=[DataRequired()])
     step = HiddenField(default="2")
 
     def __init__(self, *args, **kwargs):
@@ -46,8 +47,11 @@ class SetupRegionalForm(FlaskForm):
         texts = setup_texts(language)
         self.pais.label.text = texts["country"]
         self.moneda.label.text = texts["currency"]
+        self.zona_horaria.label.text = texts.get("timezone", "Zona horaria")
         self.pais.choices = country_choices(language)
         self.moneda.choices = currencies or []
+        from cacao_accounting.setup.catalogs import timezone_choices
+        self.zona_horaria.choices = timezone_choices()
 
 
 class SetupCompanyForm(FlaskForm):

--- a/cacao_accounting/setup/service.py
+++ b/cacao_accounting/setup/service.py
@@ -41,6 +41,7 @@ from cacao_accounting.setup.repository import (
 SETUP_LANGUAGE = "SETUP_LANGUAGE"
 SETUP_COUNTRY = "SETUP_COUNTRY"
 SETUP_CURRENCY = "SETUP_CURRENCY"
+SETUP_TIMEZONE = "SETUP_TIMEZONE"
 SETUP_COMPLETED = "SETUP_COMPLETE"
 SETUP_ENTITY = "SETUP_DEFAULT_ENTITY"
 CATALOG_FILE_ALIASES = {
@@ -126,17 +127,23 @@ def save_language(language: str) -> None:
     database.session.commit()
 
 
-def save_regional_settings(country: str, currency: str) -> None:
-    """Guarda los valores regionales de país y moneda."""
+def save_regional_settings(country: str, currency: str, timezone: str) -> None:
+    """Guarda los valores regionales de país, moneda y zona horaria."""
     from cacao_accounting.database import Currency
+    import zoneinfo
 
     selected_currency = database.session.execute(
         database.select(Currency).filter_by(code=currency, active=True)
     ).scalar_one_or_none()
     if selected_currency is None:
         raise ValueError("La moneda seleccionada no existe o no está activa.")
+
+    if timezone not in zoneinfo.available_timezones():
+        raise ValueError("La zona horaria seleccionada no es válida.")
+
     set_setup_value(SETUP_COUNTRY, country)
     set_setup_value(SETUP_CURRENCY, currency)
+    set_setup_value(SETUP_TIMEZONE, timezone)
     database.session.commit()
 
 
@@ -156,6 +163,7 @@ def get_setup_configuration() -> dict[str, Any]:
         "idioma": normalize_language(get_setup_value(SETUP_LANGUAGE, "es")),
         "pais": get_setup_value(SETUP_COUNTRY, "NI"),
         "moneda": get_setup_value(SETUP_CURRENCY, "NIO"),
+        "zona_horaria": get_setup_value(SETUP_TIMEZONE, "America/Managua"),
     }
 
 

--- a/cacao_accounting/setup/templates/setup.html
+++ b/cacao_accounting/setup/templates/setup.html
@@ -323,6 +323,13 @@
                   <div class="text-danger small mt-1">{{ form.moneda.errors[0] }}</div>
                   {% endif %}
                 </div>
+                <div class="col-md-12">
+                  <label class="form-label" for="zona_horaria">{{ texts.timezone }}</label>
+                  {{ form.zona_horaria(class="form-select form-select-lg", id="zona_horaria") }}
+                  {% if form.zona_horaria.errors %}
+                  <div class="text-danger small mt-1">{{ form.zona_horaria.errors[0] }}</div>
+                  {% endif %}
+                </div>
               </div>
             </div>
           </section>
@@ -435,13 +442,23 @@
   <script>
     (function () {
       var countryCurrencyMap = {{ country_currency_map | tojson }};
+      var countryTimezoneMap = {{ country_timezone_map | tojson }};
       var country = document.getElementById('pais');
       var currency = document.getElementById('moneda');
-      if (country && currency) {
+      var timezone = document.getElementById('zona_horaria');
+      if (country) {
         country.addEventListener('change', function () {
-          var suggested = countryCurrencyMap[country.value];
-          if (suggested && currency.querySelector('option[value="' + suggested + '"]')) {
-            currency.value = suggested;
+          if (currency) {
+            var suggested = countryCurrencyMap[country.value];
+            if (suggested && currency.querySelector('option[value="' + suggested + '"]')) {
+              currency.value = suggested;
+            }
+          }
+          if (timezone) {
+            var suggestedTz = countryTimezoneMap[country.value];
+            if (suggestedTz && timezone.querySelector('option[value="' + suggestedTz + '"]')) {
+              timezone.value = suggestedTz;
+            }
           }
         });
       }

--- a/tests/test_03webactions.py
+++ b/tests/test_03webactions.py
@@ -581,6 +581,7 @@ def test_setup_wizard_advances_between_steps(request, monkeypatch):
         class _DummyRegionalForm:
             pais = _DummyField("NI")
             moneda = _DummyField("NIO")
+            zona_horaria = _DummyField("America/Managua")
 
             def __init__(self, *args, **kwargs):
                 pass
@@ -625,7 +626,7 @@ def test_setup_wizard_advances_between_steps(request, monkeypatch):
         monkeypatch.setattr(
             setup_module,
             "save_regional_settings",
-            lambda country, currency: captured.setdefault("regional", (country, currency)),
+            lambda country, currency, timezone: captured.setdefault("regional", (country, currency, timezone)),
         )
         monkeypatch.setattr(
             setup_module,
@@ -657,11 +658,11 @@ def test_setup_wizard_advances_between_steps(request, monkeypatch):
             with client.session_transaction() as session_:
                 session_["setup_step"] = 2
 
-            response = client.post("/setup/", data={"pais": "NI", "moneda": "NIO"}, follow_redirects=False)
+            response = client.post("/setup/", data={"pais": "NI", "moneda": "NIO", "zona_horaria": "America/Managua"}, follow_redirects=False)
             assert response.status_code == 302
             with client.session_transaction() as session_:
                 assert session_["setup_step"] == 3
-            assert captured["regional"] == ("NI", "NIO")
+            assert captured["regional"] == ("NI", "NIO", "America/Managua")
 
             with client.session_transaction() as session_:
                 session_["setup_step"] = 3

--- a/tests/test_timezone_setup.py
+++ b/tests/test_timezone_setup.py
@@ -1,0 +1,115 @@
+# Copyright 2026
+# Licensed under the Apache License, Version 2.0
+
+"""Pruebas unitarias para la configuración y lógica de Zona Horaria."""
+
+import pytest
+from flask import Flask, has_request_context
+from cacao_accounting import create_app
+from cacao_accounting.database import database, CacaoConfig
+from cacao_accounting.setup.catalogs import (
+    country_timezone_map,
+    timezone_choices,
+    setup_template_context,
+)
+from cacao_accounting.setup.forms import SetupRegionalForm
+from cacao_accounting.setup.service import (
+    save_regional_settings,
+    get_setup_configuration,
+    SETUP_TIMEZONE,
+)
+
+
+@pytest.fixture
+def app_instance():
+    """Crea una instancia de la aplicación para pruebas."""
+    app = create_app(
+        {
+            "TESTING": True,
+            "SECRET_KEY": "testsecretkey",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+            "WTF_CSRF_ENABLED": False,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        }
+    )
+    with app.app_context():
+        database.create_all()
+        # Initialize default currencies
+        from cacao_accounting.database import Currency
+        nio = Currency(code="NIO", name="Córdoba Nicaragüense", decimals=2, active=True, default=True)
+        usd = Currency(code="USD", name="Dólar Estadounidense", decimals=2, active=True, default=False)
+        database.session.add(nio)
+        database.session.add(usd)
+        database.session.commit()
+    yield app
+
+
+def test_catalogs_timezone_logic():
+    """Valida la lógica de zonas horarias en catálogos."""
+    tz_map = country_timezone_map()
+    assert isinstance(tz_map, dict)
+    assert tz_map["NI"] == "America/Managua"
+    assert tz_map["US"] == "America/New_York"
+    assert tz_map["CR"] == "America/Costa_Rica"
+
+    choices = timezone_choices()
+    assert len(choices) > 0
+    assert ("America/Managua", "America/Managua") in choices
+    assert ("UTC", "UTC") in choices
+
+    context = setup_template_context("es")
+    assert "country_timezone_map" in context
+    assert context["country_timezone_map"]["NI"] == "America/Managua"
+
+
+def test_setup_regional_form(app_instance):
+    """Valida el formulario regional con el nuevo campo de zona horaria."""
+    with app_instance.test_request_context():
+        form = SetupRegionalForm(language="es", currencies=[("NIO", "NIO")])
+        assert "zona_horaria" in form
+        assert form.zona_horaria.label.text == "Zona horaria"
+        assert len(form.zona_horaria.choices) > 0
+
+
+def test_save_and_retrieve_timezone(app_instance):
+    """Valida guardar y recuperar zona horaria desde el servicio de configuración."""
+    with app_instance.app_context():
+        # Test default setup configuration (which should fall back to America/Managua)
+        config = get_setup_configuration()
+        assert config["zona_horaria"] == "America/Managua"
+
+        # Save a new valid regional settings
+        save_regional_settings("CR", "USD", "America/Costa_Rica")
+
+        # Retrieve and verify
+        config = get_setup_configuration()
+        assert config["pais"] == "CR"
+        assert config["moneda"] == "USD"
+        assert config["zona_horaria"] == "America/Costa_Rica"
+
+        # Invalid timezone should raise ValueError
+        with pytest.raises(ValueError, match="La zona horaria seleccionada no es válida."):
+            save_regional_settings("CR", "USD", "America/NonExistentTimeZone")
+
+
+def test_global_timezone_selector(app_instance):
+    """Valida que el selector global de Babel devuelva el valor correcto en contextos de request."""
+    from flask_babel import get_timezone
+
+    # With first request context
+    with app_instance.test_request_context():
+        # Default fallback
+        tz = get_timezone()
+        assert str(tz) == "America/Managua"
+
+    # Save configuration in app context
+    with app_instance.app_context():
+        save_regional_settings("CR", "USD", "America/Costa_Rica")
+        val = database.session.execute(database.select(CacaoConfig).filter_by(key="SETUP_TIMEZONE")).scalar_one_or_none()
+        print("SETUP_TIMEZONE value in DB:", val.value if val else "None")
+
+    # Retrieve again in a fresh request context
+    with app_instance.test_request_context():
+        tz = get_timezone()
+        print("Retrieved get_timezone() in fresh request context:", str(tz))
+        assert str(tz) == "America/Costa_Rica"


### PR DESCRIPTION
This pull request implements global timezone support in Cacao Accounting. During step 2 of the initial setup wizard, users can now select their preferred Country, Currency, and Timezone. A standard mapping from American countries to their respective timezones automatically suggests the best default timezone. The selected timezone is stored globally in the `CacaoConfig` table, and Flask-Babel is initialized dynamically to format dates and datetimes throughout the system in accordance with this timezone. Includes full unit tests and Playwright visual verification.

---
*PR created automatically by Jules for task [6059269227113327698](https://jules.google.com/task/6059269227113327698) started by @williamjmorenor*