### PR TITLE
Elevate Cash Flow Forecast and make Budget/Forecast cloud-only

### DIFF
--- a/cacao_accounting/bancos/cash_forecast.py
+++ b/cacao_accounting/bancos/cash_forecast.py
@@ -294,6 +294,9 @@ def cash_forecast_entry_add(forecast_id):
         database.session.rollback()
         flash(f"Error al agregar proyección: {str(exc)}", "danger")
 
+    next_url = request.args.get("next")
+    if next_url and next_url.startswith("/") and not next_url.startswith("//"):
+        return redirect(next_url)
     return redirect(url_for("bancos.cash_forecast_detail", forecast_id=forecast.id))
 
 
@@ -318,6 +321,9 @@ def cash_forecast_entry_delete(forecast_id, entry_id):
         database.session.commit()
         flash("Proyección manual eliminada correctamente.", "success")
 
+    next_url = request.args.get("next")
+    if next_url and next_url.startswith("/") and not next_url.startswith("//"):
+        return redirect(next_url)
     return redirect(url_for("bancos.cash_forecast_detail", forecast_id=forecast.id))
 
 
@@ -433,6 +439,9 @@ def cash_forecast_entry_import(forecast_id):
         database.session.rollback()
         flash(f"Error al importar archivo: {str(exc)}", "danger")
 
+    next_url = request.args.get("next")
+    if next_url and next_url.startswith("/") and not next_url.startswith("//"):
+        return redirect(next_url)
     return redirect(url_for("bancos.cash_forecast_detail", forecast_id=forecast.id))
 
 
@@ -485,3 +494,106 @@ def cash_forecast_compare():
         comparison=comparison,
         titulo="Comparación de Escenarios de Flujo de Caja",
     )
+
+
+@bancos.route("/cash-forecast/manual-entries", methods=["GET"])
+@modulo_activo("cash")
+@login_required
+def cash_forecast_manual_entries():
+    """Vista dedicada para gestionar el Forecast de Entradas manuales."""
+    if _check_desktop_mode():
+        return redirect(url_for("bancos.bancos_"))
+
+    company = request.args.get("company")
+    companies = obtener_lista_entidades_por_id_razonsocial()
+    if company in (None, "") and companies:
+        for code, name in companies:
+            if code:
+                company = code
+                break
+
+    # Obtener todos los forecast de esta compañía
+    forecasts = (
+        database.session.query(CashForecast)
+        .filter_by(company=company)
+        .order_by(CashForecast.version.asc())
+        .all()
+    )
+
+    selected_forecast_id = request.args.get("forecast_id")
+    # Default to first forecast if not specified
+    if not selected_forecast_id and forecasts:
+        selected_forecast_id = forecasts[0].id
+
+    selected_forecast = None
+    entries = []
+    if selected_forecast_id:
+        selected_forecast = database.session.get(CashForecast, selected_forecast_id)
+        if selected_forecast:
+            entries = (
+                database.session.query(CashForecastEntry)
+                .filter_by(forecast_id=selected_forecast.id)
+                .order_by(CashForecastEntry.estimated_date.asc())
+                .all()
+            )
+
+    currencies = obtener_lista_monedas()
+
+    return render_template(
+        "bancos/cash_forecast_entradas.html",
+        companies=companies,
+        selected_company=company,
+        forecasts=forecasts,
+        selected_forecast=selected_forecast,
+        entries=entries,
+        currencies=currencies,
+        titulo="Forecast de Entradas manuales",
+    )
+
+
+@bancos.route("/cash-forecast/<forecast_id>/entry/<entry_id>/edit", methods=["POST"])
+@modulo_activo("cash")
+@login_required
+def cash_forecast_entry_edit(forecast_id, entry_id):
+    """Edita un movimiento proyectado manual del pronóstico."""
+    if _check_desktop_mode():
+        return redirect(url_for("bancos.bancos_"))
+
+    forecast = database.session.get(CashForecast, forecast_id)
+    if not forecast:
+        abort(404)
+    if forecast.status != "Draft":
+        flash("No se pueden modificar pronósticos aprobados o cerrados.", "danger")
+        return redirect(url_for("bancos.cash_forecast_detail", forecast_id=forecast.id))
+
+    entry = database.session.get(CashForecastEntry, entry_id)
+    if not entry or entry.forecast_id != forecast.id:
+        abort(404)
+
+    try:
+        type_ = request.form.get("type")
+        concept = request.form.get("concept", "").strip()
+        currency = request.form.get("currency")
+        amount = Decimal(request.form.get("amount", "0"))
+        estimated_date = date.fromisoformat(request.form.get("estimated_date", ""))
+        notes = request.form.get("notes", "").strip()
+
+        if not type_ or not concept or not currency or amount <= 0 or not estimated_date:
+            flash("Todos los campos obligatorios deben tener valores válidos.", "danger")
+        else:
+            entry.type = type_
+            entry.concept = concept
+            entry.currency = currency
+            entry.amount = amount
+            entry.estimated_date = estimated_date
+            entry.notes = notes
+            database.session.commit()
+            flash("Proyección manual actualizada correctamente.", "success")
+    except Exception as exc:
+        database.session.rollback()
+        flash(f"Error al actualizar la proyección: {str(exc)}", "danger")
+
+    next_url = request.args.get("next")
+    if next_url and next_url.startswith("/") and not next_url.startswith("//"):
+        return redirect(next_url)
+    return redirect(url_for("bancos.cash_forecast_detail", forecast_id=forecast.id))

--- a/cacao_accounting/bancos/templates/bancos.html
+++ b/cacao_accounting/bancos/templates/bancos.html
@@ -93,12 +93,6 @@
         <a href="{{ url_for('bancos.bancos_conciliacion_facturas_pagos') }}">{{ _("Conciliación Facturas/Pagos") }}</a>
         {{ macros.module_status_badge(module_badge(access=acceso, required='access')) }}
       </li>
-      {% if not MODO_ESCRITORIO %}
-      <li>
-        <a href="{{ url_for('bancos.cash_forecast_list') }}">{{ _("Pronóstico de Flujo de Caja") }}</a>
-        {{ macros.module_status_badge(module_badge(access=acceso, required='access')) }}
-      </li>
-      {% endif %}
       {% else %}
       <li class="ca-no-access">
         <span>Entradas de Pago</span>
@@ -113,7 +107,37 @@
     </ul>
   </div>
 
-  {# ── Columna 3: Reportes ──────────────────────────── #}
+  {# ── Columna 3: Proyección de Flujo de Caja ───────── #}
+  {% if not MODO_ESCRITORIO %}
+  <div class="ca-module-card">
+    <h5><i class="bi bi-graph-up-arrow"></i> Proyección de Flujo de Caja</h5>
+    <ul class="ca-module-links">
+
+      {% if acceso.autorizado %}
+      <li>
+        <a href="{{ url_for('bancos.cash_forecast_list') }}">Flujo de caja (Year to Day) Real, Periodo Corriente, Proyección</a>
+        {{ macros.module_status_badge(module_badge(access=acceso, required='access')) }}
+      </li>
+      <li>
+        <a href="{{ url_for('bancos.cash_forecast_compare') }}">Comparativo de real versus presupuesto de flujo de caja</a>
+        {{ macros.module_status_badge(module_badge(access=acceso, required='reportes')) }}
+      </li>
+      <li>
+        <a href="{{ url_for('bancos.cash_forecast_manual_entries') }}">Forecast de Entradas manuales</a>
+        {{ macros.module_status_badge(module_badge(access=acceso, required='access')) }}
+      </li>
+      {% else %}
+      <li class="ca-no-access">
+        <span>Proyección de Flujo de Caja</span>
+        {{ macros.module_status_badge(module_badge(access=acceso, required='access', view_permission='access')) }}
+      </li>
+      {% endif %}
+
+    </ul>
+  </div>
+  {% endif %}
+
+  {# ── Columna 4: Reportes ──────────────────────────── #}
   <div class="ca-module-card">
     <h5><i class="bi bi-bar-chart-fill"></i> Reportes del Módulo</h5>
     <ul class="ca-module-links">

--- a/cacao_accounting/bancos/templates/bancos/cash_forecast_entradas.html
+++ b/cacao_accounting/bancos/templates/bancos/cash_forecast_entradas.html
@@ -1,0 +1,309 @@
+{% extends "base.html" %}
+{% block contenido %}
+
+{%- if TESTING -%}
+<div data-test_info="La Plantilla fue renderizada correctamente: cacao_accounting/bancos/templates/bancos/cash_forecast_entradas.html"></div>
+{%- endif -%}
+
+{% set currency = selected_company %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb lh-sm">
+    <li class="breadcrumb-item"><a href="{{ url_for('cacao_app.pagina_inicio') }}" class="link-dark"><i class="bi bi-house"></i> Inicio</a></li>
+    <li class="breadcrumb-item"><a href="{{ url_for('bancos.bancos_') }}" class="link-dark">Caja y Bancos</a></li>
+    <li class="breadcrumb-item active" aria-current="page">Forecast de Entradas manuales</li>
+  </ol>
+</nav>
+
+<div class="card mb-4 shadow-sm border-0">
+  <div class="card-header bg-white py-3 border-0">
+    <h4 class="mb-0 fw-bold"><i class="bi bi-pencil-square text-primary"></i> Forecast de Entradas manuales</h4>
+    <p class="text-muted mb-0 small">Gestione los ingresos y egresos proyectados manualmente para cada escenario de flujo de caja.</p>
+  </div>
+
+  <div class="p-3 bg-light border-top">
+    <form method="GET" action="{{ url_for('bancos.cash_forecast_manual_entries') }}" class="row g-3 align-items-end">
+      <div class="col-md-4">
+        <label for="companySelect" class="form-label small fw-bold">Compañía:</label>
+        <select name="company" id="companySelect" class="form-select form-select-sm" onchange="this.form.submit()">
+          {% for code, name in companies %}
+          <option value="{{ code }}" {% if code == selected_company %}selected{% endif %}>{{ name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <div class="col-md-4">
+        <label for="forecastSelect" class="form-label small fw-bold">Escenario / Pronóstico:</label>
+        <select name="forecast_id" id="forecastSelect" class="form-select form-select-sm" onchange="this.form.submit()">
+          <option value="">-- Seleccione un Escenario --</option>
+          {% for f in forecasts %}
+          <option value="{{ f.id }}" {% if selected_forecast and f.id == selected_forecast.id %}selected{% endif %}>{{ f.version }} ({{ f.status }})</option>
+          {% endfor %}
+        </select>
+      </div>
+    </form>
+  </div>
+</div>
+
+{% if selected_forecast %}
+<!-- Ficha de Información General del Pronóstico Seleccionado -->
+<div class="card mb-4 shadow-sm border-0">
+  <div class="card-body bg-light">
+    <div class="row g-3">
+      <div class="col-md-3">
+        <span class="text-muted d-block small">Escenario</span>
+        <strong>{{ selected_forecast.version }}</strong>
+      </div>
+      <div class="col-md-3">
+        <span class="text-muted d-block small">Estado</span>
+        <strong>
+          {% if selected_forecast.status == "Draft" %}
+          <span class="text-warning"><i class="bi bi-file-earmark-diff"></i> Borrador</span>
+          {% elif selected_forecast.status == "Approved" %}
+          <span class="text-success"><i class="bi bi-check-all"></i> Aprobado</span>
+          {% elif selected_forecast.status == "Closed" %}
+          <span class="text-secondary"><i class="bi bi-lock"></i> Cerrado</span>
+          {% else %}
+          <span class="text-dark">{{ selected_forecast.status }}</span>
+          {% endif %}
+        </strong>
+      </div>
+      <div class="col-md-3">
+        <span class="text-muted d-block small">Periodicidad</span>
+        <strong>{{ "Semanal" if selected_forecast.periodicity == "weekly" else "Mensual" }}</strong>
+      </div>
+      <div class="col-md-3">
+        <span class="text-muted d-block small">Descripción</span>
+        <p class="mb-0 text-muted small">{{ selected_forecast.description or "Sin descripción" }}</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Gestión de Proyecciones Manuales -->
+<div class="ca-card mb-4 shadow-sm border-0">
+  <div class="ca-card-header bg-white py-3 d-flex align-items-center justify-content-between">
+    <h5 class="ca-card-title mb-0"><i class="bi bi-pencil-square"></i> Proyecciones Manuales</h5>
+
+    {% if selected_forecast.status == "Draft" %}
+    <div class="d-flex gap-2">
+      <button class="btn btn-sm btn-outline-primary" type="button" data-bs-toggle="collapse" data-bs-target="#importEntryForm">
+        <i class="bi bi-file-earmark-arrow-up me-1"></i>Importar CSV / Excel
+      </button>
+      <button class="btn btn-sm btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#newEntryForm">
+        <i class="bi bi-plus-circle me-1"></i>Añadir Proyección
+      </button>
+    </div>
+    {% endif %}
+  </div>
+
+  <!-- Formulario para importar proyecciones (colapsable) -->
+  {% if selected_forecast.status == "Draft" %}
+  <div class="collapse p-4 border-bottom bg-light" id="importEntryForm">
+    <h6 class="fw-bold mb-3">Importar Proyecciones Manuales desde Archivo</h6>
+    <p class="text-muted small">
+      Seleccione un archivo <strong>CSV</strong> o <strong>XLSX</strong>. El archivo debe contener exactamente la siguiente cabecera de columnas:<br>
+      <code>type</code> (Income / Expense), <code>concept</code>, <code>currency</code>, <code>amount</code>, <code>estimated_date</code> (AAAA-MM-DD), y opcionalmente <code>notes</code>.
+    </p>
+    <form method="POST" enctype="multipart/form-data" action="{{ url_for('bancos.cash_forecast_entry_import', forecast_id=selected_forecast.id, next=request.full_path) }}" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-6">
+        <input type="file" name="file" id="import_file" class="form-control form-control-sm" accept=".csv, .xlsx" required>
+      </div>
+      <div class="col-md-6 d-flex align-items-end gap-2">
+        <button type="submit" class="btn btn-sm btn-primary">
+          <i class="bi bi-upload me-1"></i>Subir e Importar
+        </button>
+        <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#importEntryForm">
+          Cancelar
+        </button>
+      </div>
+    </form>
+  </div>
+  {% endif %}
+
+  <!-- Formulario para agregar proyecciones manuales (colapsable) -->
+  {% if selected_forecast.status == "Draft" %}
+  <div class="collapse p-4 border-bottom bg-light" id="newEntryForm">
+    <h6 class="fw-bold mb-3">Nueva Proyección Manual</h6>
+    <form method="POST" action="{{ url_for('bancos.cash_forecast_entry_add', forecast_id=selected_forecast.id, next=request.full_path) }}" class="row g-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+      <div class="col-md-3">
+        <label for="type" class="form-label small fw-bold">Tipo</label>
+        <select name="type" id="type" class="form-select form-select-sm" required>
+          <option value="Income">Ingreso (+)</option>
+          <option value="Expense">Egreso (-)</option>
+        </select>
+      </div>
+
+      <div class="col-md-3">
+        <label for="concept" class="form-label small fw-bold">Concepto</label>
+        <input type="text" name="concept" id="concept" class="form-control form-control-sm" placeholder="Ej: Nómina, Préstamo, Impuestos" required>
+      </div>
+
+      <div class="col-md-2">
+        <label for="currency" class="form-label small fw-bold">Moneda</label>
+        <select name="currency" id="currency" class="form-select form-select-sm" required>
+          {% for code, name in currencies %}
+          <option value="{{ code }}" {% if code == selected_forecast.currency %}selected{% endif %}>{{ code }} - {{ name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <div class="col-md-2">
+        <label for="amount" class="form-label small fw-bold">Monto</label>
+        <input type="number" step="0.01" name="amount" id="amount" class="form-control form-control-sm" placeholder="0.00" required>
+      </div>
+
+      <div class="col-md-2">
+        <label for="estimated_date" class="form-label small fw-bold">Fecha Estimada</label>
+        <input type="date" name="estimated_date" id="estimated_date" class="form-control form-control-sm" required>
+      </div>
+
+      <div class="col-12">
+        <label for="notes" class="form-label small fw-bold">Notas / Observaciones</label>
+        <textarea name="notes" id="notes" class="form-control form-control-sm" rows="2" placeholder="Notas adicionales..."></textarea>
+      </div>
+
+      <div class="col-12 d-flex justify-content-end gap-2">
+        <button class="btn btn-sm btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#newEntryForm">
+          Cancelar
+        </button>
+        <button type="submit" class="btn btn-sm btn-primary">
+          <i class="bi bi-plus-circle me-1"></i>Guardar Proyección
+        </button>
+      </div>
+    </form>
+  </div>
+  {% endif %}
+
+  <!-- Listado de Proyecciones Manuales -->
+  <div class="table-responsive">
+    <table class="ca-table text-nowrap align-middle">
+      <caption style="display: none;">Proyecciones manuales.</caption>
+      <thead class="table-light">
+        <tr>
+          <th scope="col">Fecha Estimada</th>
+          <th scope="col">Tipo</th>
+          <th scope="col">Concepto</th>
+          <th scope="col" class="text-end">Monto</th>
+          <th scope="col">Moneda</th>
+          <th scope="col">Notas</th>
+          {% if selected_forecast.status == "Draft" %}
+          <th scope="col">Acciones</th>
+          {% endif %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for entry in entries %}
+        <tr>
+          <td>{{ entry.estimated_date.strftime('%d/%m/%Y') }}</td>
+          <td>
+            {% if entry.type == "Income" %}
+            <span class="badge bg-success">Ingreso</span>
+            {% else %}
+            <span class="badge bg-danger">Egreso</span>
+            {% endif %}
+          </td>
+          <td>{{ entry.concept }}</td>
+          <td class="text-end fw-bold">{{ format_money_with_currency(entry.amount, entry.currency) }}</td>
+          <td>{{ entry.currency }}</td>
+          <td><small class="text-muted">{{ entry.notes or "" }}</small></td>
+          {% if selected_forecast.status == "Draft" %}
+          <td>
+            <div class="d-flex gap-2">
+              <!-- Edit Button (triggers modal) -->
+              <button type="button" class="btn btn-sm btn-outline-primary py-0 px-2" data-bs-toggle="modal" data-bs-target="#editModal-{{ entry.id }}" title="Editar línea">
+                <i class="bi bi-pencil"></i>
+              </button>
+
+              <!-- Delete Form -->
+              <form method="POST" action="{{ url_for('bancos.cash_forecast_entry_delete', forecast_id=selected_forecast.id, entry_id=entry.id, next=request.full_path) }}" onsubmit="return confirm('¿Está seguro de eliminar esta proyección?')">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-2" title="Eliminar línea">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </form>
+            </div>
+
+            <!-- Edit Modal for this specific line -->
+            <div class="modal fade" id="editModal-{{ entry.id }}" tabindex="-1" aria-labelledby="editModalLabel-{{ entry.id }}" aria-hidden="true">
+              <div class="modal-dialog">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title" id="editModalLabel-{{ entry.id }}"><i class="bi bi-pencil-square"></i> Editar Proyección Manual</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                  </div>
+                  <form method="POST" action="{{ url_for('bancos.cash_forecast_entry_edit', forecast_id=selected_forecast.id, entry_id=entry.id, next=request.full_path) }}">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="modal-body text-start">
+                      <div class="mb-3">
+                        <label for="type-{{ entry.id }}" class="form-label small fw-bold">Tipo</label>
+                        <select name="type" id="type-{{ entry.id }}" class="form-select form-select-sm" required>
+                          <option value="Income" {% if entry.type == "Income" %}selected{% endif %}>Ingreso (+)</option>
+                          <option value="Expense" {% if entry.type == "Expense" %}selected{% endif %}>Egreso (-)</option>
+                        </select>
+                      </div>
+
+                      <div class="mb-3">
+                        <label for="concept-{{ entry.id }}" class="form-label small fw-bold">Concepto</label>
+                        <input type="text" name="concept" id="concept-{{ entry.id }}" class="form-control form-control-sm" value="{{ entry.concept }}" required>
+                      </div>
+
+                      <div class="row g-2 mb-3">
+                        <div class="col-6">
+                          <label for="currency-{{ entry.id }}" class="form-label small fw-bold">Moneda</label>
+                          <select name="currency" id="currency-{{ entry.id }}" class="form-select form-select-sm" required>
+                            {% for code, name in currencies %}
+                            <option value="{{ code }}" {% if code == entry.currency %}selected{% endif %}>{{ code }}</option>
+                            {% endfor %}
+                          </select>
+                        </div>
+                        <div class="col-6">
+                          <label for="amount-{{ entry.id }}" class="form-label small fw-bold">Monto</label>
+                          <input type="number" step="0.01" name="amount" id="amount-{{ entry.id }}" class="form-control form-control-sm" value="{{ entry.amount }}" required>
+                        </div>
+                      </div>
+
+                      <div class="mb-3">
+                        <label for="estimated_date-{{ entry.id }}" class="form-label small fw-bold">Fecha Estimada</label>
+                        <input type="date" name="estimated_date" id="estimated_date-{{ entry.id }}" class="form-control form-control-sm" value="{{ entry.estimated_date.isoformat() }}" required>
+                      </div>
+
+                      <div class="mb-3">
+                        <label for="notes-{{ entry.id }}" class="form-label small fw-bold">Notas / Observaciones</label>
+                        <textarea name="notes" id="notes-{{ entry.id }}" class="form-control form-control-sm" rows="2">{{ entry.notes or "" }}</textarea>
+                      </div>
+                    </div>
+                    <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+                      <button type="submit" class="btn btn-sm btn-primary">Guardar Cambios</button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
+
+          </td>
+          {% endif %}
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="{% if selected_forecast.status == 'Draft' %}7{% else %}6{% endif %}" class="text-center text-muted py-4">
+            No se han registrado proyecciones manuales para esta versión.
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% else %}
+<div class="p-5 text-center text-muted bg-white border rounded">
+  <i class="bi bi-clipboard-x fs-1 d-block mb-3 text-secondary"></i>
+  Seleccione una compañía y un escenario/pronóstico de flujo de caja para gestionar sus entradas manuales.
+</div>
+{% endif %}
+
+{% endblock %}

--- a/cacao_accounting/contabilidad/presupuesto.py
+++ b/cacao_accounting/contabilidad/presupuesto.py
@@ -32,11 +32,21 @@ from cacao_accounting.contabilidad.auxiliares import (
     obtener_lista_monedas,
 )
 
+from cacao_accounting.runtime_mode import is_desktop_mode
+
 _ENDPOINT_LISTAR = "contabilidad.presupuestos.listar"
 _ENDPOINT_DETALLE = "contabilidad.presupuestos.detalle"
 _TEMPLATE_PRESUPUESTO_IMPORTAR = "contabilidad/presupuestos/import.html"
 
 presupuestos = Blueprint("presupuestos", __name__)
+
+
+@presupuestos.before_request
+def check_desktop_mode_for_presupuestos():
+    """Verify that we are not running in desktop mode for budget features."""
+    if is_desktop_mode():
+        flash("Gestión de presupuesto no disponible en modo DESKTOP", "danger")
+        return redirect(url_for("contabilidad.conta"))
 
 
 @presupuestos.route("/list")

--- a/cacao_accounting/contabilidad/templates/contabilidad.html
+++ b/cacao_accounting/contabilidad/templates/contabilidad.html
@@ -124,6 +124,7 @@
   </div>
 
   {# ── Columna 3: Presupuesto ───────────────────────── #}
+  {% if not MODO_ESCRITORIO %}
   <div class="ca-module-card">
     <h5><i class="bi bi-wallet2"></i> Presupuesto</h5>
     <ul class="ca-module-links">
@@ -146,6 +147,7 @@
 
     </ul>
   </div>
+  {% endif %}
 
   {# ── Columna 4: Reportes ──────────────────────────── #}
   <div class="ca-module-card">

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -3,6 +3,9 @@
 
 import pytest
 from decimal import Decimal
+from cacao_accounting.runtime_mode import is_desktop_mode
+
+pytestmark = pytest.mark.skipif(is_desktop_mode(), reason="Gestión de presupuesto no disponible en modo DESKTOP")
 from types import SimpleNamespace
 from cacao_accounting import create_app
 from cacao_accounting.contabilidad.budget_service import BudgetService, BudgetError

--- a/tests/test_budget_control.py
+++ b/tests/test_budget_control.py
@@ -3,6 +3,9 @@
 
 import pytest
 from decimal import Decimal
+from cacao_accounting.runtime_mode import is_desktop_mode
+
+pytestmark = pytest.mark.skipif(is_desktop_mode(), reason="Gestión de presupuesto no disponible en modo DESKTOP")
 from cacao_accounting import create_app
 from cacao_accounting.contabilidad.budget_service import BudgetService
 from cacao_accounting.database import (

--- a/tests/test_cash_forecast.py
+++ b/tests/test_cash_forecast.py
@@ -431,3 +431,126 @@ def test_desktop_mode_redirect(monkeypatch):
         assert (
             b"Proyecci\xc3\xb3n de flujo de caja no disponible en modo DESKTOP" in response.data
         )
+
+
+def test_edit_manual_entry_route():
+    """Test that editing a manual entry via its dedicated POST endpoint works."""
+    with test_app.test_client() as client:
+        client.post("/login", data={"usuario": "cacao", "acceso": "cacao"})
+
+        with test_app.app_context():
+            fy = db.session.query(FiscalYear).filter_by(entity="cacao").first()
+            forecast = CashForecast(
+                version="EDIT-ROUTE-TEST",
+                description="Edit test",
+                fiscal_year_id=fy.id,
+                company="cacao",
+                periodicity="monthly",
+                status="Draft",
+            )
+            db.session.add(forecast)
+            db.session.flush()
+
+            entry = CashForecastEntry(
+                forecast_id=forecast.id,
+                type="Income",
+                concept="Original Concept",
+                currency="NIO",
+                amount=Decimal("100.00"),
+                estimated_date=date(2026, 5, 10),
+            )
+            db.session.add(entry)
+            db.session.commit()
+            forecast_id = forecast.id
+            entry_id = entry.id
+
+        # Perform the edit via POST
+        response = client.post(
+            f"/cash_management/cash-forecast/{forecast_id}/entry/{entry_id}/edit",
+            data={
+                "type": "Expense",
+                "concept": "Updated Concept",
+                "currency": "NIO",
+                "amount": "250.00",
+                "estimated_date": "2026-05-12",
+                "notes": "Edited notes",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+
+        with test_app.app_context():
+            updated_entry = db.session.get(CashForecastEntry, entry_id)
+            assert updated_entry.type == "Expense"
+            assert updated_entry.concept == "Updated Concept"
+            assert updated_entry.amount == Decimal("250.00")
+            assert updated_entry.estimated_date == date(2026, 5, 12)
+            assert updated_entry.notes == "Edited notes"
+
+            # Clean up
+            db.session.delete(updated_entry)
+            db.session.delete(db.session.get(CashForecast, forecast_id))
+            db.session.commit()
+
+
+def test_manual_entries_dashboard_route():
+    """Test that the new /cash-forecast/manual-entries route renders and list entries."""
+    with test_app.test_client() as client:
+        client.post("/login", data={"usuario": "cacao", "acceso": "cacao"})
+
+        with test_app.app_context():
+            fy = db.session.query(FiscalYear).filter_by(entity="cacao").first()
+            forecast = CashForecast(
+                version="DASHBOARD-TEST",
+                description="Dashboard list test",
+                fiscal_year_id=fy.id,
+                company="cacao",
+                periodicity="monthly",
+                status="Draft",
+            )
+            db.session.add(forecast)
+            db.session.flush()
+
+            entry = CashForecastEntry(
+                forecast_id=forecast.id,
+                type="Income",
+                concept="Visible Concept",
+                currency="NIO",
+                amount=Decimal("150.00"),
+                estimated_date=date(2026, 6, 12),
+            )
+            db.session.add(entry)
+            db.session.commit()
+            forecast_id = forecast.id
+            entry_id = entry.id
+
+        response = client.get(f"/cash_management/cash-forecast/manual-entries?company=cacao&forecast_id={forecast_id}")
+        assert response.status_code == 200
+        assert b"Forecast de Entradas manuales" in response.data
+        assert b"Visible Concept" in response.data
+
+        # Clean up
+        with test_app.app_context():
+            db.session.delete(db.session.get(CashForecastEntry, entry_id))
+            db.session.delete(db.session.get(CashForecast, forecast_id))
+            db.session.commit()
+
+
+def test_budget_desktop_mode_redirect(monkeypatch):
+    """Test that if in desktop mode, the budget routes redirect with warning."""
+    with test_app.test_client() as client:
+        # Login
+        client.post("/login", data={"usuario": "cacao", "acceso": "cacao"})
+
+        # Mock is_desktop_mode to return True
+        import sys
+
+        bp_module = sys.modules["cacao_accounting.contabilidad.presupuesto"]
+        monkeypatch.setattr(bp_module, "is_desktop_mode", lambda: True)
+
+        response = client.get("/accounting/presupuestos/list", follow_redirects=True)
+        assert response.status_code == 200
+        # Check that we redirected back to contabilidad dashboard and warning is flashed
+        assert (
+            b"Gesti\xc3\xb3n de presupuesto no disponible en modo DESKTOP" in response.data
+        )

--- a/tests/test_cash_forecast.py
+++ b/tests/test_cash_forecast.py
@@ -18,6 +18,7 @@ from cacao_accounting.bancos.cash_forecast_service import (
     get_cash_forecast_matrix,
     get_forecast_comparison,
 )
+from cacao_accounting.runtime_mode import is_desktop_mode
 
 # Create custom test app
 test_app = create_app(
@@ -236,6 +237,7 @@ def test_forecast_comparison():
         db.session.commit()
 
 
+@pytest.mark.skipif(is_desktop_mode(), reason="Requires cloud mode")
 def test_routes_list_and_details():
     """Test HTTP routes for listing and displaying forecast details."""
     with test_app.test_client() as client:
@@ -323,6 +325,7 @@ def test_routes_list_and_details():
                 db.session.commit()
 
 
+@pytest.mark.skipif(is_desktop_mode(), reason="Requires cloud mode")
 def test_routes_import_entries():
     """Test importing manual entries from CSV and XLSX file."""
     with test_app.test_client() as client:
@@ -433,6 +436,7 @@ def test_desktop_mode_redirect(monkeypatch):
         )
 
 
+@pytest.mark.skipif(is_desktop_mode(), reason="Requires cloud mode")
 def test_edit_manual_entry_route():
     """Test that editing a manual entry via its dedicated POST endpoint works."""
     with test_app.test_client() as client:
@@ -493,6 +497,7 @@ def test_edit_manual_entry_route():
             db.session.commit()
 
 
+@pytest.mark.skipif(is_desktop_mode(), reason="Requires cloud mode")
 def test_manual_entries_dashboard_route():
     """Test that the new /cash-forecast/manual-entries route renders and list entries."""
     with test_app.test_client() as client:

--- a/tests/z_static_routes.py
+++ b/tests/z_static_routes.py
@@ -1,4 +1,5 @@
 # ruff: noqa: E501
+import os
 from collections import namedtuple
 
 "".encode("utf-8"),
@@ -7,6 +8,8 @@ Route = namedtuple(
     "Route",
     ["url", "text"],
 )
+
+desktop_mode = os.environ.get("CACAO_ACCOUNTING_DESKTOP") == "True" or os.environ.get("CACAO_ACCOUNTING_DESKTOP") == "true"
 
 static_rutes = [
     Route(
@@ -32,12 +35,13 @@ static_rutes = [
             ),
             "Configuración del Módulo".encode("utf-8"),
             "Registros del Módulo".encode("utf-8"),
+            "Reportes del Módulo".encode("utf-8"),
+            "Entidades".encode("utf-8"),
+        ] + ([
             "Presupuesto".encode("utf-8"),
             "Administrar Presupuestos".encode("utf-8"),
             "Real versus Presupuesto".encode("utf-8"),
-            "Reportes del Módulo".encode("utf-8"),
-            "Entidades".encode("utf-8"),
-        ],
+        ] if not desktop_mode else []),
     ),
     Route(
         url="/accounting/entity/list",


### PR DESCRIPTION
Promoted Cash Flow Projection to a primary function in the Bancos module with three menu options. Made both Budget Management (Contabilidad) and Cash Flow Projection (Bancos) cloud-only features, hiding their sections from menus in desktop mode and adding route guards to prevent direct URL access. Supported independent editing and deletion of lines in the manual entries forecast. Added tests to verify all routes.

---
*PR created automatically by Jules for task [1697783663827251576](https://jules.google.com/task/1697783663827251576) started by @williamjmorenor*