### PR TITLE
Configure HTTP Security Headers and Secure Session Cookies

### DIFF
--- a/cacao_accounting/__init__.py
+++ b/cacao_accounting/__init__.py
@@ -301,6 +301,11 @@ def create_app(ajustes: dict | None = None) -> Flask:
     # Configurar límites por defecto
     cacao_app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024
 
+    # Configurar cookies de sesión
+    cacao_app.config["SESSION_COOKIE_SECURE"] = True
+    cacao_app.config["SESSION_COOKIE_HTTPONLY"] = True
+    cacao_app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+
     setattr(cacao_app, "wsgi_app", ProxyFix(cacao_app.wsgi_app, x_for=1, x_proto=1, x_host=1))
 
     if ajustes:
@@ -341,6 +346,23 @@ def _register_app_hooks(app: Flask) -> None:
         """Establece un periodo de 30 minutos de valides de la sesión."""
         session.permanent = True
         app.permanent_session_lifetime = timedelta(minutes=30)
+
+    @app.after_request
+    def add_security_headers(response):
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; "
+            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "img-src 'self' data:; "
+            "font-src 'self' https://cdn.jsdelivr.net; "
+            "frame-ancestors 'none'"
+        )
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+        response.headers["Permissions-Policy"] = "geolocation=(), microphone=(), camera=()"
+        response.headers["Referrer-Policy"] = "same-origin"
+        return response
 
 
 # <---------------------------------------------------------------------------------------------> #

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 William José Moreno Reyes
+
+import pytest
+from cacao_accounting import create_app
+
+def test_session_cookie_configurations():
+    app = create_app({
+        "TESTING": True,
+        "SECRET_KEY": "testsecretkey",
+        "SQLALCHEMY_DATABASE_URI": "sqlite://",
+        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+    })
+    assert app.config["SESSION_COOKIE_SECURE"] is True
+    assert app.config["SESSION_COOKIE_HTTPONLY"] is True
+    assert app.config["SESSION_COOKIE_SAMESITE"] == "Lax"
+
+def test_http_security_headers():
+    app = create_app({
+        "TESTING": True,
+        "SECRET_KEY": "testsecretkey",
+        "SQLALCHEMY_DATABASE_URI": "sqlite://",
+        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+    })
+
+    with app.test_client() as client:
+        response = client.get("/")
+
+        # Verify Content-Security-Policy
+        csp = response.headers.get("Content-Security-Policy")
+        assert csp is not None
+        assert "default-src 'self'" in csp
+        assert "https://cdn.jsdelivr.net" in csp
+        assert "frame-ancestors 'none'" in csp
+
+        # Verify X-Frame-Options
+        assert response.headers.get("X-Frame-Options") == "DENY"
+
+        # Verify X-Content-Type-Options
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+
+        # Verify Strict-Transport-Security
+        assert response.headers.get("Strict-Transport-Security") == "max-age=31536000; includeSubDomains"
+
+        # Verify Permissions-Policy
+        assert response.headers.get("Permissions-Policy") == "geolocation=(), microphone=(), camera=()"
+
+        # Verify Referrer-Policy
+        assert response.headers.get("Referrer-Policy") == "same-origin"


### PR DESCRIPTION
This pull request addresses SEC-011 by configuring custom security headers (including Content Security Policy (CSP), Frame Options, Content Type Options, HSTS, Referrer Policy, and Permissions Policy) as well as hardening session cookie settings (Secure, HttpOnly, and SameSite) to protect the application from XSS, clickjacking, MIME sniffing, and session hijack attempts. A comprehensive test suite has been added to prevent regressions.

---
*PR created automatically by Jules for task [14416064578446720944](https://jules.google.com/task/14416064578446720944) started by @williamjmorenor*