### PR TITLE
Fix assign_document_identifier arguments in compras module

### DIFF
--- a/cacao_accounting/compras/__init__.py
+++ b/cacao_accounting/compras/__init__.py
@@ -3647,7 +3647,7 @@ def _create_import_landed_cost_from_request():
         document=registro,
         entity_type="import_landed_cost",
         posting_date_raw=registro.posting_date,
-        naming_series_id=None,
+        naming_series_id=request.form.get("naming_series") or None,
     )
     database.session.flush()
 

--- a/cacao_accounting/compras/__init__.py
+++ b/cacao_accounting/compras/__init__.py
@@ -3643,7 +3643,12 @@ def _create_import_landed_cost_from_request():
     database.session.add(registro)
     database.session.flush()
 
-    assign_document_identifier(registro, "import_landed_cost")
+    assign_document_identifier(
+        document=registro,
+        entity_type="import_landed_cost",
+        posting_date_raw=registro.posting_date,
+        naming_series_id=None,
+    )
     database.session.flush()
 
     # Save items from form


### PR DESCRIPTION
The `assign_document_identifier` function expects keyword-only arguments, but was being called with positional arguments in `_create_import_landed_cost_from_request`. This PR updates the call to use keyword arguments.

---
*PR created automatically by Jules for task [9181298882221028128](https://jules.google.com/task/9181298882221028128) started by @williamjmorenor*