### PR TITLE
Fix tree macro rendering to align with unit tests expectation

### DIFF
--- a/cacao_accounting/contabilidad/templates/contabilidad/tree_macros.html
+++ b/cacao_accounting/contabilidad/templates/contabilidad/tree_macros.html
@@ -86,7 +86,7 @@
         <i class="bi {{ _icon }} me-1" style="font-size:.7rem;color:#94a3b8;"></i>
         {% endif %}
         <a href="{{ _node.url }}">
-          <strong>{{ _node.code }}</strong> — {{ _node.name }}
+          <strong>{{ _node.code }}</strong>&nbsp;{{ _node.name }}
         </a>
         {%- for b in _node.badges -%}
         <span class="badge {{ b.class }}" style="font-size:.65rem;">{{ b.label }}</span>


### PR DESCRIPTION
Replaced the em-dash with a non-breaking space in `tree_macros.html` to fix the test failure in `test_01vistas.py` and ensure the full unit test suite passes successfully.

---
*PR created automatically by Jules for task [9222873876266959665](https://jules.google.com/task/9222873876266959665) started by @williamjmorenor*