### PR TITLE
Fix tree rendering separator in tree_macros template

### DIFF
--- a/cacao_accounting/contabilidad/templates/contabilidad/tree_macros.html
+++ b/cacao_accounting/contabilidad/templates/contabilidad/tree_macros.html
@@ -86,7 +86,7 @@
         <i class="bi {{ _icon }} me-1" style="font-size:.7rem;color:#94a3b8;"></i>
         {% endif %}
         <a href="{{ _node.url }}">
-          <strong>{{ _node.code }}</strong> — {{ _node.name }}
+          <strong>{{ _node.code }}</strong>&nbsp;{{ _node.name }}
         </a>
         {%- for b in _node.badges -%}
         <span class="badge {{ b.class }}" style="font-size:.65rem;">{{ b.label }}</span>


### PR DESCRIPTION
Restored the separator between code and name in `tree_macros.html` back to a non-breaking space (`&nbsp;`) to match the static route tests expectations, allowing `test_01vistas.py` to pass successfully in slow/exhaustive test mode.

---
*PR created automatically by Jules for task [11388211311325904844](https://jules.google.com/task/11388211311325904844) started by @williamjmorenor*