### PR TITLE
Run CI test jobs in parallel

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -55,7 +55,6 @@ jobs:
         run: npm test
 
   databases:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -127,7 +126,6 @@ jobs:
           SECRET_KEY=ASD123klj+aAddS LOGURU_LEVEL=WARNING CACAO_DB=postgresql+pg8000://cacao:cacao@localhost/cacao cacaoctl db init --seed
 
   desktop:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -163,7 +161,6 @@ jobs:
           python -m pytest -qq -s --exitfirst --slow=True --tb=line
 
   coverage:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Removed sequential dependencies in the CI workflow to run test jobs in parallel.

---
*PR created automatically by Jules for task [16036462518843730246](https://jules.google.com/task/16036462518843730246) started by @williamjmorenor*