### PR TITLE
fix(db): make migrations auditable across SQL engines

### DIFF
--- a/CACAO_ACCOUNTING_DEEP_AUDIT.md
+++ b/CACAO_ACCOUNTING_DEEP_AUDIT.md
@@ -6,7 +6,7 @@ Conclusión: **PARTIAL — no debe declararse listo para producción financiera 
 
 ## 1. Executive Summary
 
-El sistema tiene una base contable significativa: el posting genera `GLEntry`, existen libros paralelos, subledger de inventario, pagos/aplicaciones, revaluación FX, reportes y pruebas de regresión. La suite completa posterior a los cambios terminó con **1591 passed, 10 skipped y 242 warnings**; el esquema MariaDB pasó **214 pruebas**.
+El sistema tiene una base contable significativa: el posting genera `GLEntry`, existen libros paralelos, subledger de inventario, pagos/aplicaciones, revaluación FX, reportes y pruebas de regresión. La suite completa posterior a los cambios terminó con **1591 passed, 10 skipped y 174 warnings**; el esquema MariaDB pasó **214 pruebas**.
 
 La evidencia sí confirma cinco defectos corregidos durante esta auditoría: dos incompatibilidades del esquema con MariaDB, una agregación bancaria entre libros, el signo FX incorrecto de notas de crédito abiertas y cifras/signos incorrectos en datasets semánticos y forecast de caja. La suite verde demuestra regresión de software, pero no prueba por sí sola que todos los subledgers reconcilien con GL en todos los libros, compañías, monedas y períodos. Por eso la evaluación final es PARTIAL en todos los procesos auditados.
 
@@ -88,9 +88,10 @@ No se inventan importes ni se etiqueta cero una diferencia que no fue calculada 
 
 ## 12. End-to-End Test Results
 
-- Suite requerida en `.venv`: **1591 passed, 10 skipped, 242 warnings**, log `test_results_audit_final_20260809.log`.
+- Suite requerida en `.venv`: **1591 passed, 10 skipped, 174 warnings**, log `test_results_audit_authoritative_20260809.log`.
 - Suite completa autoritativa sobre el árbol final: **1591 passed, 10 skipped, 174 warnings**, log `test_results_audit_authoritative_20260809.log`.
 - Esquema MariaDB 11.4 en Docker (`mysql+pymysql`, puerto 3307): **214 passed**, log `test_results_mariadb_schema_current.log`.
+- Flujo de migraciones MySQL 8, PostgreSQL 16 y MariaDB 11.4: **PASS**; cada motor registró `20260809_0001` después de `db init`, en `test_results_migration_mysql_20260809.log`, `test_results_migration_postgresql_20260809.log` y `test_results_migration_mariadb_20260809.log`.
 - Pruebas focales FX/multi-ledger/reportes: **12 passed**.
 - Fixture afectado por hacer obligatorio `Entity.code`: **24 passed** de `test_line_import_api.py` tras completar el dato requerido.
 - Regresión final de pagos/conciliaciones tras el último reemplazo de bloqueo ORM: **131 passed, 41 warnings**, log `test_results_payment_last_orm_20260809.log`.
@@ -178,7 +179,8 @@ Los escenarios base, multimoneda, multilibro, inventario y 3-way están document
 
 ## 15. Medium/Low Findings
 
-- **CONTROL GAP — HIGH:** el repositorio contiene `script.py.mako` pero no se identificaron versiones de migración para aplicar `nullable=False` en bases existentes. Requiere migración explícita antes de producción.
+- **CONFIRMED BUG — HIGH (corregido):** `db migrate` declaraba éxito sin aplicar revisiones: una SQLite limpia terminaba con `alembic_version` vacío porque no existían scripts versionados. Se añadió `cacao_accounting/migrations/20260809_0001_baseline.py`, la CLI rechaza bases sin tabla `user` y `tests/test_database_migrations.py` cubre ambos casos. Sigue pendiente una migración posterior para constraints históricas de `Entity.code`/`Book.code` con preflight de nulos.
+- **CONTROL GAP — HIGH:** el baseline no sustituye la migración de datos/constraints para bases históricas que pudieran contener `NULL` en `Entity.code` o `Book.code`; debe ejecutarse con preflight y no inventar códigos.
 - **POTENTIAL RISK — MEDIUM:** existen superficies de presentación que convierten Decimal a `float`/`parseFloat`/`toFixed`; no se confirmó pérdida material en posting, pero falta una prueba de contrato de precisión UI/API.
 - **DESIGN QUESTION — LOW:** `Book.code` es globalmente único además de único por entidad; puede limitar códigos iguales entre compañías. No se confirmó impacto contable.
 - **CONTROL GAP — LOW:** la corrida focal emitió 110 warnings; después de reemplazar
@@ -190,7 +192,7 @@ Los escenarios base, multimoneda, multilibro, inventario y 3-way están document
 
 ## 16. Missing Controls
 
-1. Migraciones versionadas y verificadas para cambios de constraints.
+1. Migraciones versionadas y verificadas para cambios de constraints, incluyendo preflight de datos existentes.
 2. Job/consulta de reconciliación formal por company, book, currency y fiscal period para AR, AP, inventory, bank y tax.
 3. Alertas ante GLEntry huérfanos, subledger sin GL, journals duplicados y diferencias no cero.
 4. Pruebas de concurrencia/retry/event replay con idempotency keys persistentes.
@@ -202,14 +204,14 @@ Faltan o deben consolidarse pruebas independientes de: realized FX parcial y pos
 
 ## 18. Recommended Fix Order
 
-- **P0:** crear y probar migraciones para `Entity.code`/`Book.code`; bloquear posting si faltan company/book/period/currency; ejecutar reconciliación de saldos antes de producción.
+- **P0:** crear y probar la migración de constraints para `Entity.code`/`Book.code`; bloquear posting si faltan company/book/period/currency; ejecutar reconciliación de saldos antes de producción.
 - **P1:** implementar matriz AR/AP/inventory/bank/tax ↔ GL por dimensiones y alertas de diferencia; completar FX realized/unrealized y cierres.
 - **P2:** reforzar idempotencia, locks, retries y reversals; añadir escenarios de concurrencia y replay.
 - **P3:** eliminar floats de fronteras financieras, documentar precisión y resolver la política de unicidad de códigos.
 
 ## 19. Residual Risks
 
-La auditoría actual ejecutó MariaDB, no una corrida equivalente de PostgreSQL. No se certifica comportamiento bajo carga/concurrencia real, migración de datos existentes, autorización multi-entidad ni todas las combinaciones de cierre, impuestos y reversals. Los 242 warnings deben revisarse aunque no hayan producido fallos.
+La auditoría ejecutó flujos de migración en MySQL 8, PostgreSQL 16 y MariaDB 11.4; MariaDB se probó mediante `mysql+pymysql`, no mediante el controlador nativo `mariadb+mariadbconnector` porque no está instalado en el entorno. No se certifica comportamiento bajo carga/concurrencia real, migración de datos existentes, autorización multi-entidad ni todas las combinaciones de cierre, impuestos y reversals. Los 174 warnings deben revisarse aunque no hayan producido fallos.
 
 ## 20. Final Assessment
 

--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -3,6 +3,45 @@
 > Este archivo documenta decisiones de diseño, arquitectura y hitos clave del proyecto.
 > Para detalles de implementación por sesión, consultar el historial de git.
 
+## 2026-08-09 — Control de migraciones y validación multi-motor
+
+### Petición
+
+Continuar la auditoría y probar el flujo de migraciones en MySQL, PostgreSQL y
+MariaDB, manteniendo el uso de `.venv` y evidencia reproducible en logs.
+
+### Implementación y evidencia
+
+- Se confirmó que `db migrate` podía devolver código 0 sin aplicar revisiones:
+  el repositorio tenía `script.py.mako`, pero no una revisión en la ruta que
+  Flask-Alembic inspecciona. Una SQLite limpia terminó con `alembic_version`
+  vacío.
+- Se añadió el baseline versionado
+  `cacao_accounting/migrations/20260809_0001_baseline.py`. No modifica datos:
+  registra el esquema que `db init` crea con SQLAlchemy para habilitar futuras
+  migraciones ordenadas.
+- `db migrate` ahora rechaza explícitamente una base sin tabla `user`, en vez
+  de informar una migración exitosa sin esquema.
+- Se añadieron `tests/test_database_migrations.py` para probar bootstrap,
+  revisión no vacía y rechazo de base no inicializada.
+- Evidencia multi-motor: MySQL 8 PASS (`test_results_migration_mysql_20260809.log`),
+  PostgreSQL 16 PASS (`test_results_migration_postgresql_20260809.log`) y
+  MariaDB 11.4 PASS mediante `mysql+pymysql`
+  (`test_results_migration_mariadb_20260809.log`); cada uno registró
+  `20260809_0001`.
+- La URI `mariadb+pymysql` sigue siendo rechazada por la validación actual;
+  no se presenta como soporte nativo certificado. El controlador `mariadb`
+  requiere MariaDB Connector/C y no está instalado en `.venv`.
+- La prueba focal de migraciones terminó **2 passed**. La suite autoritativa
+  previa continúa en **1591 passed, 10 skipped, 174 warnings**.
+
+### Continuidad
+
+La siguiente corrección P0 sigue siendo una migración de constraints para
+`Entity.code` y `Book.code` con preflight de datos históricos, además de las
+reconciliaciones AR/AP/inventario/bancos/Tax por compañía, libro, moneda y
+período. El baseline no debe confundirse con esa migración de constraints.
+
 ## 2026-08-09 — Auditoría profunda multi-motor y reconciliación de cifras
 
 ### Petición

--- a/cacao_accounting/cli.py
+++ b/cacao_accounting/cli.py
@@ -247,11 +247,16 @@ def db_migrate(head: str, revision: str | None) -> None:
     termina con éxito (código 0). Esto permite ejecutarlo de forma segura
     en el inicio de un contenedor Docker.
     """
+    from sqlalchemy import inspect
+
     from cacao_accounting import alembic
+    from cacao_accounting.database import database
 
     app = _obtener_aplicacion()
     with app.app_context():
         try:
+            if not inspect(database.engine).has_table("user"):
+                raise RuntimeError("La base de datos no está inicializada; ejecute primero 'cacaoctl db init'.")
             target = revision or head
             alembic.upgrade(target=target)
             _mensaje_exito("Migraciones aplicadas correctamente.")

--- a/cacao_accounting/migrations/20260809_0001_baseline.py
+++ b/cacao_accounting/migrations/20260809_0001_baseline.py
@@ -1,0 +1,22 @@
+"""Register the schema created by ``cacaoctl db init`` as the Alembic baseline.
+
+The application currently creates its complete schema with SQLAlchemy's
+``create_all`` during first-time initialization. This revision deliberately
+does not alter existing data; it records the known schema state so subsequent
+schema changes can be delivered as real, ordered Alembic revisions.
+"""
+
+from collections.abc import Sequence
+
+revision = "20260809_0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Record the initial SQLAlchemy-created schema as the migration baseline."""
+
+
+def downgrade() -> None:
+    """Remove the baseline marker without dropping application tables."""

--- a/tests/test_database_migrations.py
+++ b/tests/test_database_migrations.py
@@ -1,0 +1,80 @@
+"""Regression tests for the Alembic migration entry point."""
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_db_init_and_migrate_record_a_real_revision(tmp_path: Path) -> None:
+    """The documented bootstrap flow must leave a non-empty Alembic revision."""
+    database_path = tmp_path / "migration.sqlite"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CACAO_TEST": "True",
+            "CACAO_DATABASE_URL": f"sqlite:///{database_path}",
+            "SECRET_KEY": "ASD123kljaAddS",
+            "CACAO_USER": "cacao",
+            "CACAO_PSWD": "cacao",
+            "LOGURU_LEVEL": "WARNING",
+        }
+    )
+    command = [sys.executable, "-c", "from cacao_accounting import command; command()"]
+
+    initialized = subprocess.run(
+        [*command, "db", "init"],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    assert initialized.returncode == 0, initialized.stdout + initialized.stderr
+
+    migrated = subprocess.run(
+        [*command, "db", "migrate"],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    assert migrated.returncode == 0, migrated.stdout + migrated.stderr
+
+    with sqlite3.connect(database_path) as connection:
+        revision = connection.execute("SELECT version_num FROM alembic_version").fetchall()
+
+    assert revision == [("20260809_0001",)]
+
+
+def test_db_migrate_rejects_an_uninitialized_database(tmp_path: Path) -> None:
+    """Migration must not report success when there is no application schema."""
+    database_path = tmp_path / "uninitialized.sqlite"
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "CACAO_TEST": "True",
+            "CACAO_DATABASE_URL": f"sqlite:///{database_path}",
+            "SECRET_KEY": "ASD123kljaAddS",
+            "LOGURU_LEVEL": "WARNING",
+        }
+    )
+
+    migrated = subprocess.run(
+        [sys.executable, "-c", "from cacao_accounting import command; command()", "db", "migrate"],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+
+    assert migrated.returncode == 1
+    assert "La base de datos no está inicializada" in migrated.stdout


### PR DESCRIPTION
## What changed
- Add the first Alembic baseline revision.
- Reject `db migrate` when the application schema is not initialized.
- Add regression tests for a recorded revision and the uninitialized-database guard.
- Document MySQL, PostgreSQL, and MariaDB migration evidence.

## Why
`db migrate` previously returned success with no revision scripts applied, leaving `alembic_version` empty and making deployment state unauditable.

## Validation
- Black, Ruff, Flake8, and Mypy pass locally.
- Migration regression: 2 passed.
- MySQL 8 migration flow: pass.
- PostgreSQL 16 migration flow: pass.
- MariaDB 11.4 migration flow via `mysql+pymysql`: pass.