### PR TITLE
Reverse FX adjustments for refund settlements

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -2069,3 +2069,11 @@ CI detectó además que el caller de `StockEntry` requiere conservar su mensaje 
   idempotente. Se actualizó `tests/test_database_migrations.py` para esperar
   la revisión `20260809_0001` y se eliminó el test de códigos legacy que
   validaba la migración 0002 ya borrada.
+
+## 2026-08-10 — Reverse FX adjustments for refund settlements
+
+- Implemented FX adjustment and payment discount reversal for refund settlements (`refund_confirmed`).
+- Modified `_build_exchange_difference_line`, `_build_unrealized_exchange_difference_line`, and `_build_unrealized_party_offset_line` to negate the `exchange_difference` when `context.event_type == "refund_confirmed"`.
+- Modified `_build_payment_discount_line` to reverse the debit/credit side when `context.event_type == "refund_confirmed"`.
+- Added unit test `test_supplier_refund_mapping_reverses_exchange` in `tests/engines/test_mapper.py` verifying a supplier refund with carrying value 3,600 and cash receipt of 3,700 properly balances and produces a 100 credit to exchange gain.
+- All code formatted with black, checked with ruff, flake8, and mypy, and verified using pytest.

--- a/cacao_accounting/accounting_engine/orchestrator/mapper.py
+++ b/cacao_accounting/accounting_engine/orchestrator/mapper.py
@@ -270,6 +270,8 @@ class AccountingMapper:
         exchange_difference: Decimal,
     ) -> JournalEntryLineProforma:
         """Build the realized exchange gain/loss line in company currency."""
+        if context.event_type == "refund_confirmed":
+            exchange_difference = -exchange_difference
         side = "credit" if exchange_difference > 0 else "debit"
         account_id = (
             context.references.get("exchange_gain_account_id")
@@ -294,6 +296,8 @@ class AccountingMapper:
         exchange_difference: Decimal,
     ) -> JournalEntryLineProforma:
         """Build the unrealized exchange revaluation line in company currency."""
+        if context.event_type == "refund_confirmed":
+            exchange_difference = -exchange_difference
         side = "credit" if exchange_difference > 0 else "debit"
         account_id = (
             context.references.get("unrealized_exchange_gain_account_id")
@@ -318,6 +322,8 @@ class AccountingMapper:
         exchange_difference: Decimal,
     ) -> JournalEntryLineProforma:
         """Build the control-account offset required for unrealized revaluation."""
+        if context.event_type == "refund_confirmed":
+            exchange_difference = -exchange_difference
         side = "debit" if exchange_difference > 0 else "credit"
         return self._build_line(
             context,
@@ -338,7 +344,11 @@ class AccountingMapper:
         payment_discount_amount: Decimal,
     ) -> JournalEntryLineProforma:
         """Build the payment discount line in company currency."""
-        side = "credit" if context.transaction_direction == "purchase" else "debit"
+        is_refund = context.event_type == "refund_confirmed"
+        if is_refund:
+            side = "debit" if context.transaction_direction == "purchase" else "credit"
+        else:
+            side = "credit" if context.transaction_direction == "purchase" else "debit"
         account_id = context.references.get("payment_discount_account_id")
         return self._build_line(
             context,

--- a/tests/engines/test_mapper.py
+++ b/tests/engines/test_mapper.py
@@ -252,3 +252,52 @@ def test_collection_mapping_includes_discount_and_unrealized_revaluation():
     assert discount_line.debit == Decimal("73.6")
     assert unrealized_line.credit == Decimal("30")
     assert unrealized_offset.debit == Decimal("30")
+
+
+def test_supplier_refund_mapping_reverses_exchange():
+    """A supplier refund with carrying value 3600 (AP 100 USD @ 36.0) and cash receipt of 3700 (100 USD @ 37.0)
+
+    should produce a credit of 3600, debit of 3700, and a 100 credit to exchange gain.
+    """
+    ctx = CalculationContext(
+        company_id="C1",
+        document_type="payment_entry",
+        event_type="refund_confirmed",
+        transaction_direction="purchase",
+        transaction_date=date(2025, 6, 1),
+        posting_date=date(2025, 6, 1),
+        party_type="supplier",
+        party_id="S1",
+        currency="USD",
+        company_currency="NIO",
+        exchange_rate=Decimal("36.0"),
+        references=AccountingReferences(
+            party_account="2101",
+            cash_account="1010",
+            custom_references={
+                "settlement_exchange_rate": Decimal("37.0"),
+                "exchange_gain_account_id": "4205",
+                "exchange_loss_account_id": "6901",
+            },
+        ),
+    )
+    settlement = SettlementResult(
+        gross_settlement_amount=Decimal("100"),
+        cash_amount=Decimal("100"),
+        exchange_difference=Decimal("-100"),  # Normal settlement difference would be loss, but reversed it's a gain of 100
+    )
+
+    mapper = AccountingMapper()
+    proforma = mapper.map_to_proforma(ctx, settlement=settlement)
+
+    assert proforma.is_balanced
+    assert sum(line.debit for line in proforma.lines) == Decimal("3700.00")
+    assert sum(line.credit for line in proforma.lines) == Decimal("3700.00")
+
+    payable_line = next(line for line in proforma.lines if line.account_id == "2101")
+    bank_line = next(line for line in proforma.lines if line.account_id == "1010")
+    gain_line = next(line for line in proforma.lines if line.account_id == "4205")
+
+    assert payable_line.credit == Decimal("3600.0")
+    assert bank_line.debit == Decimal("3700.0")
+    assert gain_line.credit == Decimal("100.0")


### PR DESCRIPTION
This change updates the AccountingMapper's FX adjustment and payment discount builders to automatically reverse sign/direction when the calculation context is for a refund settlement event (event_type == 'refund_confirmed'). This ensures refund settlements with carry differences balance correctly and assign appropriate gains or losses.

---
*PR created automatically by Jules for task [8804477081678472849](https://jules.google.com/task/8804477081678472849) started by @williamjmorenor*