### PR TITLE
Return persisted record for repeated exchange revaluations

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -2069,3 +2069,10 @@ CI detectó además que el caller de `StockEntry` requiere conservar su mensaje 
   idempotente. Se actualizó `tests/test_database_migrations.py` para esperar
   la revisión `20260809_0001` y se eliminó el test de códigos legacy que
   validaba la migración 0002 ya borrada.
+
+## 2026-08-10 — Retorno de registro existente para ejecuciones repetidas de revalorización cambiaria
+
+- Se corrigió un error en `ExchangeRevaluationService.run()` donde ejecuciones repetidas para la misma compañía, año y mes retornaban un objeto `ExchangeRevaluation` no persistido y transitorio, cuyo `id` de base de datos permanecía como `None`. Esto provocaba fallos de redirección, problemas en las rutas de detalle y errores en los controles de cierre mensual.
+- Se modificó la lógica para retornar directamente la ejecución persistida `existing_run`.
+- Se actualizaron las pruebas unitarias en `tests/test_exchange_revaluation.py` para asegurar la idempotencia del servicio mediante aserciones de identidad (`second is first`).
+- Se verificó la conformidad del código mediante formateo con `black` y chequeo estricto con `mypy`, `ruff` y `flake8`.

--- a/cacao_accounting/contabilidad/exchange_revaluation_service.py
+++ b/cacao_accounting/contabilidad/exchange_revaluation_service.py
@@ -113,24 +113,7 @@ class ExchangeRevaluationService:
             .first()
         )
         if existing_run:
-            return ExchangeRevaluation(
-                company=company,
-                posting_date=period.end,
-                document_date=period.end,
-                run_date=period.end,
-                year=year,
-                month=month,
-                status=EXCHANGE_REVALUATION_STATUS_NO_CHANGES,
-                docstatus=1,
-                created_by=user_id,
-                processed_documents_count=0,
-                affected_documents_count=0,
-                total_gain=Decimal("0"),
-                total_loss=Decimal("0"),
-                currency=summary_ledger.currency,
-                generated_journal=False,
-                voucher_type=EXCHANGE_REVALUATION_ENTITY_TYPE,
-            )
+            return existing_run
 
         candidates = self._open_candidates(company, period.end, summary_ledger.id)
 

--- a/tests/test_exchange_revaluation.py
+++ b/tests/test_exchange_revaluation.py
@@ -95,7 +95,7 @@ def _login(client, user_id: str) -> None:
 def _seed_accounts() -> dict[str, object]:
     from cacao_accounting.database import Accounts, database
 
-    accounts = {
+    accounts: dict[str, object] = {
         "ar": Accounts(
             entity="cacao",
             code="1105",
@@ -322,9 +322,8 @@ def test_service_does_not_duplicate_previous_revaluation(app_ctx):
     second = service.run(company="cacao", year=2026, month=5, user_id="admin")
 
     assert first.status == "posted"
-    assert second.status == "completed_no_changes"
-    assert second.generated_journal is False
-    assert second.affected_documents_count == 0
+    assert second.id == first.id
+    assert second is first
 
 
 def test_service_does_not_duplicate_partial_balance_revaluation(app_ctx):
@@ -337,8 +336,8 @@ def test_service_does_not_duplicate_partial_balance_revaluation(app_ctx):
     second = service.run(company="cacao", year=2026, month=5, user_id="admin")
 
     assert first.status == "posted"
-    assert second.status == "completed_no_changes"
-    assert second.affected_documents_count == 0
+    assert second.id == first.id
+    assert second is first
 
 
 def test_service_raises_controlled_error_when_closing_rate_is_missing(app_ctx):


### PR DESCRIPTION
Resolved the issue where repeated executions of exchange revaluation for the same company, year, and month returned an unpersisted transient object with a database ID of None. Now it correctly returns the already-persisted existing run, maintaining correct idempotency and database referencing. Also updated associated tests to verify this correct behavior and fixed related typing issues with mypy.

---
*PR created automatically by Jules for task [9402942894405772035](https://jules.google.com/task/9402942894405772035) started by @williamjmorenor*