### PR TITLE
Exclude future-dated invoices from late 2-way match in S2P

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -2069,3 +2069,14 @@ CI detectó además que el caller de `StockEntry` requiere conservar su mensaje 
   idempotente. Se actualizó `tests/test_database_migrations.py` para esperar
   la revisión `20260809_0001` y se eliminó el test de códigos legacy que
   validaba la migración 0002 ya borrada.
+
+## 2026-08-10 — Corrección de facturas futuras en compensación 2-way
+
+### Petición
+Limitar la detección de facturas 2-way precedentes a una recepción de compra en `_late_two_way_invoice_amounts` para que excluya facturas aprobadas con fecha de contabilización posterior a la de la recepción.
+
+### Implementación
+- Modificado `_late_two_way_invoice_amounts` en `cacao_accounting/accounting_engine/document_builders.py`.
+- Se agregó el filtro `PurchaseInvoice.posting_date <= document.posting_date` a la consulta de selección de facturas de compra.
+- Se agregó una prueba unitaria robusta `test_late_two_way_invoice_amounts_excludes_future_invoices` en `tests/test_07posting_engine.py` para asegurar que las facturas con fecha posterior sean correctamente excluidas y evitar regresiones.
+- Se verificaron Black, Ruff, mypy, compilación y git diff --check; todas las pruebas pasaron exitosamente.

--- a/cacao_accounting/accounting_engine/document_builders.py
+++ b/cacao_accounting/accounting_engine/document_builders.py
@@ -225,6 +225,7 @@ def _late_two_way_invoice_amounts(document: PurchaseReceipt) -> dict[str, Decima
             PurchaseInvoice.purchase_receipt_id.is_(None),
             PurchaseInvoice.docstatus == 1,
             PurchaseInvoice.is_return.is_(False),
+            PurchaseInvoice.posting_date <= document.posting_date,
         )
     ).scalars()
     amounts: dict[str, Decimal] = {}

--- a/tests/test_07posting_engine.py
+++ b/tests/test_07posting_engine.py
@@ -4013,3 +4013,76 @@ def test_operational_posting_multimoneda_real(app_ctx):
         assert original is not None
         assert reversal.debit_in_account_currency == original.credit_in_account_currency
         assert reversal.credit_in_account_currency == original.debit_in_account_currency
+
+
+def test_late_two_way_invoice_amounts_excludes_future_invoices(app_ctx):
+    """Test that _late_two_way_invoice_amounts excludes future dated invoices."""
+    from cacao_accounting.accounting_engine.document_builders import _late_two_way_invoice_amounts
+    from cacao_accounting.database import (
+        PurchaseReceipt,
+        PurchaseInvoice,
+        PurchaseInvoiceItem,
+        database,
+    )
+
+    receipt = PurchaseReceipt(
+        company="cacao",
+        posting_date=date(2026, 5, 10),
+        supplier_id="SUPP-LTW",
+        purchase_order_id="PO-LTW",
+    )
+    database.session.add(receipt)
+    database.session.flush()
+
+    # Preceding invoice (on or before posting date of receipt)
+    invoice_preceding = PurchaseInvoice(
+        company="cacao",
+        posting_date=date(2026, 5, 10),
+        supplier_id="SUPP-LTW",
+        purchase_order_id="PO-LTW",
+        purchase_receipt_id=None,
+        docstatus=1,
+        is_return=False,
+    )
+    database.session.add(invoice_preceding)
+    database.session.flush()
+
+    invoice_preceding_item = PurchaseInvoiceItem(
+        purchase_invoice_id=invoice_preceding.id,
+        item_code="ITEM-A",
+        qty=Decimal("10"),
+        rate=Decimal("5.00"),
+        amount=Decimal("50.00"),
+    )
+    database.session.add(invoice_preceding_item)
+
+    # Future-dated/subsequent invoice (posted after receipt's posting date)
+    invoice_future = PurchaseInvoice(
+        company="cacao",
+        posting_date=date(2026, 5, 11),
+        supplier_id="SUPP-LTW",
+        purchase_order_id="PO-LTW",
+        purchase_receipt_id=None,
+        docstatus=1,
+        is_return=False,
+    )
+    database.session.add(invoice_future)
+    database.session.flush()
+
+    invoice_future_item = PurchaseInvoiceItem(
+        purchase_invoice_id=invoice_future.id,
+        item_code="ITEM-B",
+        qty=Decimal("5"),
+        rate=Decimal("10.00"),
+        amount=Decimal("50.00"),
+    )
+    database.session.add(invoice_future_item)
+    database.session.commit()
+
+    # Run the utility function
+    amounts = _late_two_way_invoice_amounts(receipt)
+
+    # Check results
+    assert "ITEM-A" in amounts
+    assert amounts["ITEM-A"] == Decimal("50.00")
+    assert "ITEM-B" not in amounts


### PR DESCRIPTION
This change limits the detection of preceding 2-way invoices to those posted on or before the receipt's posting date, preventing inventory debit and artificial expense credit reporting distortions in backdated purchase receipts when a future-dated 2-way invoice exists.

---
*PR created automatically by Jules for task [1549209137916721269](https://jules.google.com/task/1549209137916721269) started by @williamjmorenor*