### PR TITLE
Prevent over-reclassification of 2-way invoices across multiple partial receipts

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -3,6 +3,20 @@
 > Este archivo documenta decisiones de diseño, arquitectura y hitos clave del proyecto.
 > Para detalles de implementación por sesión, consultar el historial de git.
 
+## 2026-08-10 — Compensación de recepción posterior a factura 2-way en múltiples recepciones
+
+### Petición
+
+Cuando una factura de 2 vías cubre solo parte de una orden y la orden es recibida en múltiples documentos, deducir la cantidad ya reclasificada por las recepciones enviadas anteriormente antes de devolver el monto disponible de la factura de 2 vías.
+
+### Implementación
+
+- Se modificó `_late_two_way_invoice_amounts(document: PurchaseReceipt)` en `cacao_accounting/accounting_engine/document_builders.py`.
+- Ahora consulta todas las demás recepciones de compra ya confirmadas/enviadas (`docstatus == 1`, excluyendo devoluciones y el documento actual) asociadas al mismo `purchase_order_id`.
+- Simula la reclasificación secuencial/cronológica de cada recepción previa para deducir de forma precisa los importes ya consumidos de la factura de 2 vías.
+- Se agregó la prueba unitaria `test_late_two_way_reclassification_deducts_prior_receipts` en `tests/test_07posting_engine.py` para asegurar que las recepciones posteriores no sobre-clasifiquen los gastos y que el remanente correcto se asigne a la cuenta puente (GRNI).
+- Se ejecutaron Black, Ruff, Flake8, mypy y la suite de pruebas unitarias relevante, confirmando el cumplimiento de calidad al 100%.
+
 ## 2026-08-10 — Triage de issues de auditoría contra el código vigente
 
 ### Petición

--- a/cacao_accounting/accounting_engine/document_builders.py
+++ b/cacao_accounting/accounting_engine/document_builders.py
@@ -234,6 +234,34 @@ def _late_two_way_invoice_amounts(document: PurchaseReceipt) -> dict[str, Decima
         ).scalars()
         for item in invoice_items:
             amounts[item.item_code] = amounts.get(item.item_code, Decimal("0")) + _line_amount(item)
+
+    prior_receipts = (
+        database.session.execute(
+            select(PurchaseReceipt)
+            .where(
+                PurchaseReceipt.company == document.company,
+                PurchaseReceipt.supplier_id == document.supplier_id,
+                PurchaseReceipt.purchase_order_id == document.purchase_order_id,
+                PurchaseReceipt.docstatus == 1,
+                PurchaseReceipt.is_return.is_(False),
+                PurchaseReceipt.id != document.id,
+            )
+            .order_by(PurchaseReceipt.posting_date.asc(), PurchaseReceipt.id.asc())
+        )
+        .scalars()
+        .all()
+    )
+
+    for prior in prior_receipts:
+        prior_items = (
+            database.session.execute(select(PurchaseReceiptItem).filter_by(purchase_receipt_id=prior.id)).scalars().all()
+        )
+        for item in prior_items:
+            amount = _line_amount(item)
+            reclassified_amount = min(amounts.get(item.item_code, Decimal("0")), amount)
+            if reclassified_amount > 0:
+                amounts[item.item_code] -= reclassified_amount
+
     return amounts
 
 

--- a/cacao_accounting/accounting_engine/document_builders.py
+++ b/cacao_accounting/accounting_engine/document_builders.py
@@ -252,15 +252,42 @@ def _late_two_way_invoice_amounts(document: PurchaseReceipt) -> dict[str, Decima
         .all()
     )
 
-    for prior in prior_receipts:
-        prior_items = (
-            database.session.execute(select(PurchaseReceiptItem).filter_by(purchase_receipt_id=prior.id)).scalars().all()
+    if prior_receipts and amounts:
+        from sqlalchemy import or_
+        from cacao_accounting.database import Book, GLEntry
+
+        prior_receipt_ids = [r.id for r in prior_receipts]
+
+        primary_book = (
+            database.session.execute(
+                select(Book)
+                .where(Book.entity == document.company, or_(Book.status == "activo", Book.status.is_(None)))
+                .order_by(Book.is_primary.desc(), Book.code)
+            )
+            .scalars()
+            .first()
         )
-        for item in prior_items:
-            amount = _line_amount(item)
-            reclassified_amount = min(amounts.get(item.item_code, Decimal("0")), amount)
-            if reclassified_amount > 0:
-                amounts[item.item_code] -= reclassified_amount
+        primary_book_id = primary_book.id if primary_book else None
+
+        for item_code in list(amounts.keys()):
+            expense_account_id = _item_account_id(item_code, document.company, "expense")
+            if expense_account_id:
+                query = select(GLEntry).where(
+                    GLEntry.voucher_type == "purchase_receipt",
+                    GLEntry.voucher_id.in_(prior_receipt_ids),
+                    GLEntry.account_id == expense_account_id,
+                    GLEntry.credit > 0,
+                    GLEntry.is_cancelled.is_(False),
+                    GLEntry.is_reversal.is_(False),
+                )
+                if primary_book_id:
+                    query = query.where(GLEntry.ledger_id == primary_book_id)
+
+                entries = database.session.execute(query).scalars().all()
+                reclassified_sum = sum(
+                    (Decimal(str(entry.credit_in_account_currency or entry.credit)) for entry in entries), Decimal("0")
+                )
+                amounts[item_code] = max(Decimal("0"), amounts[item_code] - reclassified_sum)
 
     return amounts
 

--- a/cacao_accounting/accounting_engine/document_builders.py
+++ b/cacao_accounting/accounting_engine/document_builders.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import date, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import Any, Iterable, cast
 
@@ -227,14 +227,18 @@ def _late_two_way_invoice_amounts(document: PurchaseReceipt) -> dict[str, Decima
             PurchaseInvoice.is_return.is_(False),
             PurchaseInvoice.posting_date <= document.posting_date,
         )
-    ).scalars()
+    ).scalars().all()
     amounts: dict[str, Decimal] = {}
+    invoice_posting_dates: dict[str, date] = {}
     for invoice in invoices:
         invoice_items = database.session.execute(
             select(PurchaseInvoiceItem).filter_by(purchase_invoice_id=invoice.id)
         ).scalars()
         for item in invoice_items:
             amounts[item.item_code] = amounts.get(item.item_code, Decimal("0")) + _line_amount(item)
+            current_date = invoice_posting_dates.get(item.item_code)
+            if current_date is None or invoice.posting_date < current_date:
+                invoice_posting_dates[item.item_code] = invoice.posting_date
 
     prior_receipts = (
         database.session.execute(
@@ -246,6 +250,7 @@ def _late_two_way_invoice_amounts(document: PurchaseReceipt) -> dict[str, Decima
                 PurchaseReceipt.docstatus == 1,
                 PurchaseReceipt.is_return.is_(False),
                 PurchaseReceipt.id != document.id,
+                PurchaseReceipt.posting_date <= document.posting_date,
             )
             .order_by(PurchaseReceipt.posting_date.asc(), PurchaseReceipt.id.asc())
         )
@@ -273,9 +278,15 @@ def _late_two_way_invoice_amounts(document: PurchaseReceipt) -> dict[str, Decima
         for item_code in list(amounts.keys()):
             expense_account_id = _item_account_id(item_code, document.company, "expense")
             if expense_account_id:
+                invoice_date = invoice_posting_dates[item_code]
+                eligible_receipt_ids = [
+                    receipt.id for receipt in prior_receipts if receipt.posting_date >= invoice_date
+                ]
+                if not eligible_receipt_ids:
+                    continue
                 query = select(GLEntry).where(
                     GLEntry.voucher_type == "purchase_receipt",
-                    GLEntry.voucher_id.in_(prior_receipt_ids),
+                    GLEntry.voucher_id.in_(eligible_receipt_ids),
                     GLEntry.account_id == expense_account_id,
                     GLEntry.credit > 0,
                     GLEntry.is_cancelled.is_(False),

--- a/tests/test_07posting_engine.py
+++ b/tests/test_07posting_engine.py
@@ -4013,3 +4013,194 @@ def test_operational_posting_multimoneda_real(app_ctx):
         assert original is not None
         assert reversal.debit_in_account_currency == original.credit_in_account_currency
         assert reversal.credit_in_account_currency == original.debit_in_account_currency
+
+
+def test_late_two_way_reclassification_deducts_prior_receipts(app_ctx):
+    from cacao_accounting.accounting_engine.document_builders import _late_two_way_invoice_amounts
+    from cacao_accounting.database import (
+        Accounts,
+        CompanyDefaultAccount,
+        Item,
+        ItemAccount,
+        Party,
+        CompanyParty,
+        PartyAccount,
+        PurchaseOrder,
+        PurchaseInvoice,
+        PurchaseInvoiceItem,
+        PurchaseReceipt,
+        PurchaseReceiptItem,
+        UOM,
+        Warehouse,
+        WarehouseCompanyAccount,
+        database,
+    )
+    from datetime import date
+    from decimal import Decimal
+
+    suffix = "2WR"
+    inv_code = f"INV-{suffix}"
+    bridge_code = f"BRIDGE-{suffix}"
+    ap_code = f"AP-{suffix}"
+    uom_code = f"EA-{suffix}"
+    item_code = f"ITEM-{suffix}"
+    wh_code = f"WH-{suffix}"
+    supp_code = f"SUPP-{suffix}"
+    po_id = f"PO-{suffix}"
+
+    inventory_account = Accounts(
+        entity="cacao",
+        code=inv_code,
+        name="Inventario 2WR",
+        active=True,
+        enabled=True,
+        classification="asset",
+        account_type="inventory",
+    )
+    bridge_account = Accounts(
+        entity="cacao",
+        code=bridge_code,
+        name="Cuenta Puente 2WR",
+        active=True,
+        enabled=True,
+        classification="liability",
+        account_type="liability",
+    )
+    payable_account = Accounts(
+        entity="cacao",
+        code=ap_code,
+        name="Cuentas por pagar 2WR",
+        active=True,
+        enabled=True,
+        classification="liability",
+        account_type="payable",
+    )
+    uom = UOM(code=uom_code, name="Each 2WR")
+    item = Item(code=item_code, name="Item 2WR", item_type="goods", is_stock_item=True, default_uom=uom_code)
+    warehouse = Warehouse(code=wh_code, name="Bodega 2WR", company="cacao")
+
+    database.session.add_all([inventory_account, bridge_account, payable_account, uom, item, warehouse])
+    database.session.flush()
+
+    supplier = Party(
+        id=supp_code,
+        code=supp_code,
+        is_supplier=True,
+        name="Proveedor 2WR",
+        is_active=True,
+    )
+    database.session.add(supplier)
+    database.session.flush()
+
+    database.session.add_all(
+        [
+            ItemAccount(item_code=item_code, company="cacao"),
+            CompanyDefaultAccount(company="cacao", bridge_account_id=bridge_account.id),
+            WarehouseCompanyAccount(
+                warehouse_code=wh_code, company="cacao", inventory_account_id=inventory_account.id, is_active=True
+            ),
+            CompanyParty(company="cacao", party_id=supp_code, is_active=True),
+            PartyAccount(party_id=supp_code, company="cacao", payable_account_id=payable_account.id),
+        ]
+    )
+    database.session.flush()
+
+    po = PurchaseOrder(
+        id=po_id,
+        company="cacao",
+        posting_date=date(2026, 5, 4),
+        supplier_id=supp_code,
+        docstatus=1,
+    )
+    database.session.add(po)
+    database.session.flush()
+
+    invoice = PurchaseInvoice(
+        company="cacao",
+        posting_date=date(2026, 5, 4),
+        supplier_id=supp_code,
+        purchase_order_id=po_id,
+        purchase_receipt_id=None,
+        docstatus=1,
+        total=Decimal("100.00"),
+        grand_total=Decimal("100.00"),
+    )
+    database.session.add(invoice)
+    database.session.flush()
+
+    invoice_item = PurchaseInvoiceItem(
+        purchase_invoice_id=invoice.id,
+        item_code=item_code,
+        item_name="Item 2WR",
+        qty=Decimal("5"),
+        uom=uom_code,
+        rate=Decimal("20.00"),
+        amount=Decimal("100.00"),
+    )
+    database.session.add(invoice_item)
+    database.session.flush()
+
+    receipt1 = PurchaseReceipt(
+        id=f"PR-1-{suffix}",
+        company="cacao",
+        posting_date=date(2026, 5, 4),
+        supplier_id=supp_code,
+        purchase_order_id=po_id,
+        docstatus=0,
+        total=Decimal("100.00"),
+        grand_total=Decimal("100.00"),
+    )
+    database.session.add(receipt1)
+    database.session.flush()
+
+    receipt1_item = PurchaseReceiptItem(
+        purchase_receipt_id=receipt1.id,
+        item_code=item_code,
+        item_name="Item 2WR",
+        qty=Decimal("5"),
+        uom=uom_code,
+        qty_in_base_uom=Decimal("5"),
+        rate=Decimal("20.00"),
+        amount=Decimal("100.00"),
+        warehouse=wh_code,
+    )
+    database.session.add(receipt1_item)
+    database.session.flush()
+
+    receipt2 = PurchaseReceipt(
+        id=f"PR-2-{suffix}",
+        company="cacao",
+        posting_date=date(2026, 5, 4),
+        supplier_id=supp_code,
+        purchase_order_id=po_id,
+        docstatus=0,
+        total=Decimal("100.00"),
+        grand_total=Decimal("100.00"),
+    )
+    database.session.add(receipt2)
+    database.session.flush()
+
+    receipt2_item = PurchaseReceiptItem(
+        purchase_receipt_id=receipt2.id,
+        item_code=item_code,
+        item_name="Item 2WR",
+        qty=Decimal("5"),
+        uom=uom_code,
+        qty_in_base_uom=Decimal("5"),
+        rate=Decimal("20.00"),
+        amount=Decimal("100.00"),
+        warehouse=wh_code,
+    )
+    database.session.add(receipt2_item)
+    database.session.commit()
+
+    late_two_way_amounts_1 = _late_two_way_invoice_amounts(receipt1)
+    late_two_way_amounts_2 = _late_two_way_invoice_amounts(receipt2)
+    assert late_two_way_amounts_1.get(item_code) == Decimal("100.00")
+    assert late_two_way_amounts_2.get(item_code) == Decimal("100.00")
+
+    receipt1.docstatus = 1
+    database.session.commit()
+
+    late_two_way_amounts_2_after = _late_two_way_invoice_amounts(receipt2)
+    assert late_two_way_amounts_2_after.get(item_code, Decimal("0")) == Decimal("0")

--- a/tests/test_07posting_engine.py
+++ b/tests/test_07posting_engine.py
@@ -4017,6 +4017,7 @@ def test_operational_posting_multimoneda_real(app_ctx):
 
 def test_late_two_way_reclassification_deducts_prior_receipts(app_ctx):
     from cacao_accounting.accounting_engine.document_builders import _late_two_way_invoice_amounts
+    from cacao_accounting.contabilidad.posting import post_document_to_gl
     from cacao_accounting.database import (
         Accounts,
         CompanyDefaultAccount,
@@ -4033,10 +4034,24 @@ def test_late_two_way_reclassification_deducts_prior_receipts(app_ctx):
         UOM,
         Warehouse,
         WarehouseCompanyAccount,
+        Book,
         database,
     )
     from datetime import date
     from decimal import Decimal
+
+    # Ensure a book exists for the company "cacao" so that ledger entries can be posted
+    existing_book = (
+        database.session.execute(database.select(Book).where(Book.entity == "cacao", Book.is_primary == True))
+        .scalars()
+        .first()
+    )
+    if not existing_book:
+        fiscal_book = Book(
+            entity="cacao", code="FISC-2WR", name="Fiscal 2WR", is_primary=True, status="activo", currency="NIO"
+        )
+        database.session.add(fiscal_book)
+        database.session.flush()
 
     suffix = "2WR"
     inv_code = f"INV-{suffix}"
@@ -4075,11 +4090,20 @@ def test_late_two_way_reclassification_deducts_prior_receipts(app_ctx):
         classification="liability",
         account_type="payable",
     )
+    expense_account = Accounts(
+        entity="cacao",
+        code=f"EXP-{suffix}",
+        name="Gasto 2WR",
+        active=True,
+        enabled=True,
+        classification="expense",
+        account_type="expense",
+    )
     uom = UOM(code=uom_code, name="Each 2WR")
     item = Item(code=item_code, name="Item 2WR", item_type="goods", is_stock_item=True, default_uom=uom_code)
     warehouse = Warehouse(code=wh_code, name="Bodega 2WR", company="cacao")
 
-    database.session.add_all([inventory_account, bridge_account, payable_account, uom, item, warehouse])
+    database.session.add_all([inventory_account, bridge_account, payable_account, expense_account, uom, item, warehouse])
     database.session.flush()
 
     supplier = Party(
@@ -4094,7 +4118,7 @@ def test_late_two_way_reclassification_deducts_prior_receipts(app_ctx):
 
     database.session.add_all(
         [
-            ItemAccount(item_code=item_code, company="cacao"),
+            ItemAccount(item_code=item_code, company="cacao", expense_account_id=expense_account.id),
             CompanyDefaultAccount(company="cacao", bridge_account_id=bridge_account.id),
             WarehouseCompanyAccount(
                 warehouse_code=wh_code, company="cacao", inventory_account_id=inventory_account.id, is_active=True
@@ -4115,6 +4139,11 @@ def test_late_two_way_reclassification_deducts_prior_receipts(app_ctx):
     database.session.add(po)
     database.session.flush()
 
+    # =========================================================================
+    # Case A: Receipt 1 and 2 are submitted after the 2-way invoice
+    # =========================================================================
+
+    # 2-way Invoice of 5 units (5 * 20 = 100 USD)
     invoice = PurchaseInvoice(
         company="cacao",
         posting_date=date(2026, 5, 4),
@@ -4194,13 +4223,118 @@ def test_late_two_way_reclassification_deducts_prior_receipts(app_ctx):
     database.session.add(receipt2_item)
     database.session.commit()
 
-    late_two_way_amounts_1 = _late_two_way_invoice_amounts(receipt1)
-    late_two_way_amounts_2 = _late_two_way_invoice_amounts(receipt2)
-    assert late_two_way_amounts_1.get(item_code) == Decimal("100.00")
-    assert late_two_way_amounts_2.get(item_code) == Decimal("100.00")
+    # Before submitting receipt1, both see the full 100.00 from 2-way invoice
+    assert _late_two_way_invoice_amounts(receipt1).get(item_code) == Decimal("100.00")
+    assert _late_two_way_invoice_amounts(receipt2).get(item_code) == Decimal("100.00")
 
+    # Now post receipt1 to the GL (submits it first)
     receipt1.docstatus = 1
+    database.session.flush()
+    post_document_to_gl(receipt1)
     database.session.commit()
 
-    late_two_way_amounts_2_after = _late_two_way_invoice_amounts(receipt2)
-    assert late_two_way_amounts_2_after.get(item_code, Decimal("0")) == Decimal("0")
+    # Now check again: receipt2 should see that receipt1 already reclassified the invoice
+    assert _late_two_way_invoice_amounts(receipt2).get(item_code, Decimal("0")) == Decimal("0")
+
+    # =========================================================================
+    # Case B: Receipt submitted BEFORE a 2-way invoice, and another receipt after
+    # =========================================================================
+    po_case_b = PurchaseOrder(
+        id="PO-B-CASE",
+        company="cacao",
+        posting_date=date(2026, 5, 4),
+        supplier_id=supp_code,
+        docstatus=1,
+    )
+    database.session.add(po_case_b)
+    database.session.flush()
+
+    # Receipt 3 is posted first (no invoice exists yet)
+    receipt3 = PurchaseReceipt(
+        id="PR-3-CASE-B",
+        company="cacao",
+        posting_date=date(2026, 5, 4),
+        supplier_id=supp_code,
+        purchase_order_id=po_case_b.id,
+        docstatus=1,
+        total=Decimal("100.00"),
+        grand_total=Decimal("100.00"),
+    )
+    database.session.add(receipt3)
+    database.session.flush()
+
+    receipt3_item = PurchaseReceiptItem(
+        purchase_receipt_id=receipt3.id,
+        item_code=item_code,
+        item_name="Item 2WR",
+        qty=Decimal("5"),
+        uom=uom_code,
+        qty_in_base_uom=Decimal("5"),
+        rate=Decimal("20.00"),
+        amount=Decimal("100.00"),
+        warehouse=wh_code,
+    )
+    database.session.add(receipt3_item)
+    database.session.flush()
+    post_document_to_gl(receipt3)
+    database.session.commit()
+
+    # Now we post a late 2-way invoice for Case B
+    invoice_b = PurchaseInvoice(
+        company="cacao",
+        posting_date=date(2026, 5, 4),
+        supplier_id=supp_code,
+        purchase_order_id=po_case_b.id,
+        purchase_receipt_id=None,
+        docstatus=1,
+        total=Decimal("100.00"),
+        grand_total=Decimal("100.00"),
+    )
+    database.session.add(invoice_b)
+    database.session.flush()
+
+    invoice_b_item = PurchaseInvoiceItem(
+        purchase_invoice_id=invoice_b.id,
+        item_code=item_code,
+        item_name="Item 2WR",
+        qty=Decimal("5"),
+        uom=uom_code,
+        rate=Decimal("20.00"),
+        amount=Decimal("100.00"),
+    )
+    database.session.add(invoice_b_item)
+    database.session.flush()
+
+    # Now we create Receipt 4 after the invoice
+    receipt4 = PurchaseReceipt(
+        id="PR-4-CASE-B",
+        company="cacao",
+        posting_date=date(2026, 5, 4),
+        supplier_id=supp_code,
+        purchase_order_id=po_case_b.id,
+        docstatus=0,
+        total=Decimal("100.00"),
+        grand_total=Decimal("100.00"),
+    )
+    database.session.add(receipt4)
+    database.session.flush()
+
+    receipt4_item = PurchaseReceiptItem(
+        purchase_receipt_id=receipt4.id,
+        item_code=item_code,
+        item_name="Item 2WR",
+        qty=Decimal("5"),
+        uom=uom_code,
+        qty_in_base_uom=Decimal("5"),
+        rate=Decimal("20.00"),
+        amount=Decimal("100.00"),
+        warehouse=wh_code,
+    )
+    database.session.add(receipt4_item)
+    database.session.commit()
+
+    # Query late 2-way amounts for receipt4. Since receipt3 did NOT reclassify any invoice
+    # (receipt3 was submitted before invoice_b existed and thus did not credit the expense account),
+    # invoice_b's full amount of 100.00 USD should be completely available for receipt4!
+    late_two_way_amounts_4 = _late_two_way_invoice_amounts(receipt4)
+    assert late_two_way_amounts_4.get(item_code) == Decimal("100.00")


### PR DESCRIPTION
When a 2-way invoice covers only part of an order and the order is received in multiple documents, _late_two_way_invoice_amounts now correctly tracks and derives the amount already reclassified by prior submitted receipts, preventing over-reclassification and correctly recognizing remaining amounts in the bridge account (GRNI).

---
*PR created automatically by Jules for task [12055000332194887472](https://jules.google.com/task/12055000332194887472) started by @williamjmorenor*