### PR TITLE
Scale purchase reconciliation price variance by matched quantity

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -2069,3 +2069,9 @@ CI detectó además que el caller de `StockEntry` requiere conservar su mensaje 
   idempotente. Se actualizó `tests/test_database_migrations.py` para esperar
   la revisión `20260809_0001` y se eliminó el test de códigos legacy que
   validaba la migración 0002 ya borrada.
+
+## 2026-08-10 — Corrección de la escala de variación de precio para facturas parciales de compras
+
+- Petición: Escalar la varianza de precio usando la cantidad de la factura conciliada (`min(invoice_group.qty, reference_qty)`) en lugar de toda la cantidad de la referencia no facturada (`reference_qty`) para evitar varianzas incorrectas y fallas falsas de tolerancia en facturas parciales.
+- Plan implementado: Modificado el cálculo de `total_price_difference` tanto en el matching 2-way como en el 3-way de `cacao_accounting/compras/purchase_reconciliation_service.py` para usar `min(invoice_group.qty, reference_qty)`. Agregada la prueba `test_partial_invoice_price_variance_scaling` en `tests/test_08_reconciliation_reports.py` para cubrir ambos escenarios.
+- Verificación: Las pruebas unitarias fueron ejecutadas y pasaron exitosamente.

--- a/cacao_accounting/compras/purchase_reconciliation_service.py
+++ b/cacao_accounting/compras/purchase_reconciliation_service.py
@@ -560,7 +560,7 @@ def _reconcile_three_way(invoice: PurchaseInvoice, config: MatchingConfig) -> Pu
         amount_difference = invoice_group.amount - reference_amount
 
         total_amount += matched_amount
-        total_price_difference += price_difference * reference_qty
+        total_price_difference += price_difference * min(invoice_group.qty, reference_qty)
         total_amount_difference += amount_difference
         total_invoiced_qty += invoice_group.qty
         total_received_qty += reference_qty
@@ -642,7 +642,7 @@ def _reconcile_two_way(invoice: PurchaseInvoice, config: MatchingConfig) -> Purc
         amount_difference = invoice_group.amount - reference_amount
 
         total_amount += matched_amount
-        total_price_difference += price_difference * reference_qty
+        total_price_difference += price_difference * min(invoice_group.qty, reference_qty)
         total_amount_difference += amount_difference
         total_invoiced_qty += invoice_group.qty
         total_ordered_qty += reference_qty

--- a/tests/test_08_reconciliation_reports.py
+++ b/tests/test_08_reconciliation_reports.py
@@ -4280,3 +4280,148 @@ def test_purchase_reconciliation_currency_mismatch_rejected(app_ctx):
 
     with pytest.raises(PurchaseReconciliationError, match="en la misma moneda"):
         reconcile_purchase_invoice(invoice.id)
+
+
+def test_partial_invoice_price_variance_scaling(app_ctx):
+    from cacao_accounting.compras.purchase_reconciliation_service import (
+        reconcile_purchase_invoice,
+        PurchaseMatchingConfig,
+        MatchingType,
+        seed_matching_config_for_company,
+    )
+    from cacao_accounting.database import (
+        UOM,
+        Item,
+        Warehouse,
+        PurchaseReceipt,
+        PurchaseReceiptItem,
+        PurchaseInvoice,
+        PurchaseInvoiceItem,
+        PurchaseOrder,
+        PurchaseOrderItem,
+        database,
+    )
+
+    seed_matching_config_for_company("cacao")
+
+    # 1. Test 3-way price difference scaling
+    database.session.add_all(
+        [
+            UOM(code="EA-SCALE", name="Each SCALE"),
+            Item(code="ITEM-SCALE", name="Item SCALE", item_type="goods", is_stock_item=True, default_uom="EA-SCALE"),
+            Warehouse(code="WH-SCALE", name="Bodega SCALE", company="cacao"),
+        ]
+    )
+    database.session.flush()
+
+    # Ensure matching config is 3-way
+    cfg = database.session.execute(database.select(PurchaseMatchingConfig).filter_by(company="cacao")).scalar_one()
+    cfg.matching_type = MatchingType.THREE_WAY
+    database.session.commit()
+
+    # 100-unit receipt at rate 10 (amount = 1000)
+    receipt = PurchaseReceipt(
+        company="cacao", posting_date=date(2026, 5, 1), supplier_id="SUPP-SCALE", transaction_currency="USD", docstatus=1
+    )
+    database.session.add(receipt)
+    database.session.flush()
+
+    database.session.add(
+        PurchaseReceiptItem(
+            purchase_receipt_id=receipt.id,
+            item_code="ITEM-SCALE",
+            qty=Decimal("100"),
+            qty_in_base_uom=Decimal("100"),
+            uom="EA-SCALE",
+            rate=Decimal("10.00"),
+            amount=Decimal("1000.00"),
+            warehouse="WH-SCALE",
+        )
+    )
+
+    # Partial invoice of 10 units at rate 12 (amount = 120)
+    # Price difference is 12 - 10 = 2 per unit
+    # Expected price variance for 10 units should be 10 * 2 = 20, not 100 * 2 = 200 (if reference_qty was used)
+    invoice = PurchaseInvoice(
+        company="cacao",
+        posting_date=date(2026, 5, 2),
+        supplier_id="SUPP-SCALE",
+        purchase_receipt_id=receipt.id,
+        transaction_currency="USD",
+        docstatus=1,
+    )
+    database.session.add(invoice)
+    database.session.flush()
+
+    database.session.add(
+        PurchaseInvoiceItem(
+            purchase_invoice_id=invoice.id,
+            item_code="ITEM-SCALE",
+            qty=Decimal("10"),
+            uom="EA-SCALE",
+            rate=Decimal("12.00"),
+            amount=Decimal("120.00"),
+            warehouse="WH-SCALE",
+        )
+    )
+    database.session.commit()
+
+    result_3w = reconcile_purchase_invoice(invoice.id)
+    assert result_3w.price_difference == Decimal("20.00")
+
+    # 2. Test 2-way price difference scaling
+    # Switch matching config to 2-way
+    cfg.matching_type = MatchingType.TWO_WAY
+    database.session.commit()
+
+    order = PurchaseOrder(
+        company="cacao",
+        posting_date=date(2026, 5, 1),
+        supplier_id="SUPP-SCALE2",
+        transaction_currency="USD",
+        docstatus=1,
+    )
+    database.session.add(order)
+    database.session.flush()
+
+    database.session.add(
+        PurchaseOrderItem(
+            purchase_order_id=order.id,
+            item_code="ITEM-SCALE",
+            qty=Decimal("100"),
+            qty_in_base_uom=Decimal("100"),
+            uom="EA-SCALE",
+            rate=Decimal("10.00"),
+            amount=Decimal("1000.00"),
+        )
+    )
+
+    invoice_2w = PurchaseInvoice(
+        company="cacao",
+        posting_date=date(2026, 5, 2),
+        supplier_id="SUPP-SCALE2",
+        purchase_order_id=order.id,
+        transaction_currency="USD",
+        docstatus=1,
+    )
+    database.session.add(invoice_2w)
+    database.session.flush()
+
+    database.session.add(
+        PurchaseInvoiceItem(
+            purchase_invoice_id=invoice_2w.id,
+            item_code="ITEM-SCALE",
+            qty=Decimal("10"),
+            uom="EA-SCALE",
+            rate=Decimal("12.00"),
+            amount=Decimal("120.00"),
+        )
+    )
+    database.session.commit()
+
+    result_2w = reconcile_purchase_invoice(invoice_2w.id)
+    assert result_2w.price_difference == Decimal("20.00")
+
+    # Restore matching config back to 3-way
+    cfg.matching_type = MatchingType.THREE_WAY
+    database.session.commit()


### PR DESCRIPTION
Scaled the price variance in purchase reconciliation matching logic by the actually matched invoice quantity instead of the entire unmatched reference quantity. This correctly handles partial invoice reconciliation price differences, preventing incorrect matching failures or inflated variance totals. Validated with comprehensive tests.

---
*PR created automatically by Jules for task [12347446954270349363](https://jules.google.com/task/12347446954270349363) started by @williamjmorenor*