### PR TITLE
Reconstruct valuation at the requested cutoff

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -2077,3 +2077,15 @@ CI detectó además que el caller de `StockEntry` requiere conservar su mensaje 
   ventas, aislamiento por libro y controles de inventario.
 - El merge conserva los cambios entrantes de migraciones, dependencias y
   pruebas, sin descartar funcionalidad existente.
+
+## 2026-08-11 — Reconstrucción de valuación de inventario al corte
+
+### Petición
+
+Reconstruir la valoración de inventario en la fecha de corte (`date_to`) a partir de los deltas de las capas de valoración en lugar de confiar en los campos `remaining_qty` y `remaining_stock_value` del registro de la última capa, ya que éstos se pueblan del `StockBin` actual y se contaminan con movimientos posteriores.
+
+### Implementación
+
+- Se modificó `get_inventory_valuation` en `cacao_accounting/reportes/services.py` para reconstruir las cantidades y valores al corte a partir de los deltas (`layer.qty` y `layer.stock_value_difference`) de las capas correspondientes de `StockValuationLayer`.
+- Se agruparon los deltas por `(item_code, warehouse)` y se excluyeron de forma consistente aquellas filas con cantidad final igual a `0`, tal como se hace en la generación del Kardex y existencias.
+- Se verificaron la consistencia de tipos, formato, estilo y la compatibilidad con los tests existentes.

--- a/cacao_accounting/reportes/services.py
+++ b/cacao_accounting/reportes/services.py
@@ -2662,21 +2662,31 @@ def get_inventory_valuation(filters: OperationalReportFilters) -> PaginatedRepor
         query = query.filter_by(warehouse=filters.warehouse)
     if filters.date_to:
         query = query.where(StockValuationLayer.posting_date <= filters.date_to)
-    latest_layers: dict[tuple[str, str], StockValuationLayer] = {}
+    grouped: dict[tuple[str, str], dict[str, Any]] = {}
     for layer in database.session.execute(
         query.order_by(StockValuationLayer.posting_date, StockValuationLayer.created, StockValuationLayer.id)
     ).scalars():
-        latest_layers[(layer.item_code, layer.warehouse)] = layer
+        key = (layer.item_code, layer.warehouse)
+        if key not in grouped:
+            grouped[key] = {
+                "item_code": layer.item_code,
+                "warehouse": layer.warehouse,
+                "remaining_qty": Decimal("0"),
+                "remaining_stock_value": Decimal("0"),
+            }
+        grouped[key]["remaining_qty"] += _decimal_value(layer.qty)
+        grouped[key]["remaining_stock_value"] += _decimal_value(layer.stock_value_difference)
     rows = [
         ReportRow(
             {
-                "item_code": layer.item_code,
-                "warehouse": layer.warehouse,
-                "remaining_qty": _decimal_value(layer.remaining_qty),
-                "remaining_stock_value": _decimal_value(layer.remaining_stock_value),
+                "item_code": val["item_code"],
+                "warehouse": val["warehouse"],
+                "remaining_qty": _decimal_value(val["remaining_qty"]),
+                "remaining_stock_value": _decimal_value(val["remaining_stock_value"]),
             }
         )
-        for layer in latest_layers.values()
+        for val in grouped.values()
+        if _decimal_value(val["remaining_qty"]) != Decimal("0")
     ]
     rows.sort(key=lambda row: (str(row.values["item_code"]), str(row.values["warehouse"])))
     return PaginatedReport(


### PR DESCRIPTION
Reconstruct inventory valuation by summing StockValuationLayer deltas (qty and stock_value_difference) up to the requested cutoff (date_to) instead of trusting the stored remaining quantity and remaining stock value of the latest layer.

---
*PR created automatically by Jules for task [92258221099596091](https://jules.google.com/task/92258221099596091) started by @williamjmorenor*