### PR TITLE
Fix: Exclude cancelled reconciliation items from bank reconciliation report

### DIFF
--- a/cacao_accounting/reportes/services.py
+++ b/cacao_accounting/reportes/services.py
@@ -1177,36 +1177,60 @@ def _bank_orphan_diagnostics(company: str, as_of_date: date | None) -> list[Repo
 
 def get_reconciliation_report(company: str, as_of_date: date | None = None) -> PaginatedReport:
     """Devuelve reconciliaciones bancarias y conciliaciones de compras pendientes."""
+    from cacao_accounting.database import AuditTrail
+
     query = (
         select(Reconciliation, ReconciliationItem)
         .join(
             ReconciliationItem,
             ReconciliationItem.reconciliation_id == Reconciliation.id,
         )
-        .filter(
-            Reconciliation.company == company,
-            ReconciliationItem.status != "cancelled",
-        )
+        .filter(Reconciliation.company == company)
     )
     if as_of_date:
         query = query.where(Reconciliation.recon_date <= as_of_date)
 
-    rows = [
-        ReportRow(
-            values={
-                "reconciliation_id": reconciliation.id,
-                "recon_date": reconciliation.recon_date,
-                "recon_type": reconciliation.recon_type,
-                "source_type": item.source_type or item.reference_type,
-                "source_id": item.source_id or item.reference_id,
-                "target_type": item.target_type,
-                "target_id": item.target_id,
-                "amount": _decimal_value(item.allocated_amount or item.amount),
-                "status": item.status,
-            }
+    cancel_dates = {}
+    if as_of_date:
+        audit_records = database.session.execute(
+            select(AuditTrail.document_id, AuditTrail.timestamp).where(
+                AuditTrail.document_type == "payment_entry",
+                AuditTrail.action == "cancelled",
+            )
+        ).all()
+        for doc_id, timestamp in audit_records:
+            if timestamp:
+                cancel_dates[doc_id] = timestamp.date()
+
+    rows = []
+    for reconciliation, item in database.session.execute(query).all():
+        if item.status == "cancelled":
+            cancel_date = cancel_dates.get(item.target_id)
+            if as_of_date and cancel_date and cancel_date > as_of_date:
+                # Cancellation happened after the cutoff, so historically it was reconciled
+                status = "reconciled"
+            else:
+                # Cancelled on or before the cutoff (or no cutoff specified), so exclude it
+                continue
+        else:
+            status = item.status
+
+        rows.append(
+            ReportRow(
+                values={
+                    "reconciliation_id": reconciliation.id,
+                    "recon_date": reconciliation.recon_date,
+                    "recon_type": reconciliation.recon_type,
+                    "source_type": item.source_type or item.reference_type,
+                    "source_id": item.source_id or item.reference_id,
+                    "target_type": item.target_type,
+                    "target_id": item.target_id,
+                    "amount": _decimal_value(item.allocated_amount or item.amount),
+                    "status": status,
+                }
+            )
         )
-        for reconciliation, item in database.session.execute(query).all()
-    ]
+
     bank_total = sum((_decimal_value(row.values["amount"]) for row in rows), Decimal("0"))
     purchase_pending = get_purchase_reconciliation_pending(company=company, as_of_date=as_of_date)
     for pending in purchase_pending:

--- a/cacao_accounting/reportes/services.py
+++ b/cacao_accounting/reportes/services.py
@@ -1183,7 +1183,10 @@ def get_reconciliation_report(company: str, as_of_date: date | None = None) -> P
             ReconciliationItem,
             ReconciliationItem.reconciliation_id == Reconciliation.id,
         )
-        .filter(Reconciliation.company == company)
+        .filter(
+            Reconciliation.company == company,
+            ReconciliationItem.status != "cancelled",
+        )
     )
     if as_of_date:
         query = query.where(Reconciliation.recon_date <= as_of_date)

--- a/tests/test_08_reconciliation_reports.py
+++ b/tests/test_08_reconciliation_reports.py
@@ -4682,6 +4682,7 @@ def test_post_bank_difference_deposit_and_withdrawal(app_ctx):
 
 def test_cancelled_reconciliation_item_excluded_from_reconciliation_report(app_ctx):
     """Verifica que get_reconciliation_report no sume ReconciliationItem cancelados en bank_reconciled_amount."""
+    from datetime import datetime, timezone
     from cacao_accounting.database import (
         Accounts,
         Bank,
@@ -4690,6 +4691,7 @@ def test_cancelled_reconciliation_item_excluded_from_reconciliation_report(app_c
         PaymentEntry,
         Reconciliation,
         ReconciliationItem,
+        AuditTrail,
         database,
     )
     from cacao_accounting.bancos import _apply_payment_cancellation_hooks
@@ -4754,12 +4756,33 @@ def test_cancelled_reconciliation_item_excluded_from_reconciliation_report(app_c
 
     # Cancel the payment, which triggers marking status as 'cancelled'
     _apply_payment_cancellation_hooks(payment)
+    # Manually add the AuditTrail entry for the cancellation on June 10, 2026
+    cancel_log = AuditTrail(
+        document_type="payment_entry",
+        document_id=payment.id,
+        action="cancelled",
+        timestamp=datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc),
+        company="cacao",
+    )
+    database.session.add(cancel_log)
     database.session.commit()
 
     # Verify that the ReconciliationItem status was updated to 'cancelled'
     database.session.refresh(recon_item)
     assert recon_item.status == "cancelled"
 
-    # After cancellation, the report should exclude the item, meaning bank_reconciled_amount is 0
-    report_after = get_reconciliation_report(company="cacao")
-    assert report_after.totals["bank_reconciled_amount"] == Decimal("0")
+    # Test as_of_date BEFORE the cancellation date (e.g. May 31, 2026) -> should PRESERVE the reconciled item!
+    report_cutoff_before = get_reconciliation_report(company="cacao", as_of_date=date(2026, 5, 31))
+    assert report_cutoff_before.totals["bank_reconciled_amount"] == Decimal("100.00")
+    # Verify status is displayed as "reconciled" in the report as of that date
+    matching_rows = [row for row in report_cutoff_before.rows if row.values["target_id"] == payment.id]
+    assert len(matching_rows) == 1
+    assert matching_rows[0].values["status"] == "reconciled"
+
+    # Test as_of_date AFTER the cancellation date (e.g. June 15, 2026) -> should EXCLUDE the cancelled item!
+    report_cutoff_after = get_reconciliation_report(company="cacao", as_of_date=date(2026, 6, 15))
+    assert report_cutoff_after.totals["bank_reconciled_amount"] == Decimal("0")
+
+    # Test current report (no as_of_date specified) -> should EXCLUDE the cancelled item!
+    report_current = get_reconciliation_report(company="cacao")
+    assert report_current.totals["bank_reconciled_amount"] == Decimal("0")

--- a/tests/test_08_reconciliation_reports.py
+++ b/tests/test_08_reconciliation_reports.py
@@ -4678,3 +4678,88 @@ def test_post_bank_difference_deposit_and_withdrawal(app_ctx):
     ).scalar_one()
     assert withdrawal_difference_item.amount == Decimal("15")
     assert withdrawal_difference_item.allocated_amount == Decimal("15")
+
+
+def test_cancelled_reconciliation_item_excluded_from_reconciliation_report(app_ctx):
+    """Verifica que get_reconciliation_report no sume ReconciliationItem cancelados en bank_reconciled_amount."""
+    from cacao_accounting.database import (
+        Accounts,
+        Bank,
+        BankAccount,
+        BankTransaction,
+        PaymentEntry,
+        Reconciliation,
+        ReconciliationItem,
+        database,
+    )
+    from cacao_accounting.bancos import _apply_payment_cancellation_hooks
+    from cacao_accounting.reportes.services import get_reconciliation_report
+
+    bank_gl = Accounts(entity="cacao", code="BANK-TEST", name="Test Bank", classification="asset")
+    bank = Bank(name="Banco Test")
+    database.session.add_all([bank_gl, bank])
+    database.session.flush()
+
+    bank_account = BankAccount(
+        bank_id=bank.id,
+        company="cacao",
+        account_name="Test Bank Account",
+        currency="NIO",
+        gl_account_id=bank_gl.id,
+    )
+    database.session.add(bank_account)
+    database.session.flush()
+
+    transaction = BankTransaction(
+        bank_account_id=bank_account.id,
+        posting_date=date(2026, 5, 5),
+        deposit=Decimal("100.00"),
+    )
+    database.session.add(transaction)
+    database.session.flush()
+
+    payment = PaymentEntry(
+        company="cacao",
+        posting_date=date(2026, 5, 5),
+        payment_type="receive",
+        bank_account_id=bank_account.id,
+        paid_amount=Decimal("100.00"),
+        docstatus=1,
+    )
+    database.session.add(payment)
+    database.session.flush()
+
+    reconciliation = Reconciliation(company="cacao", recon_date=date(2026, 5, 5), recon_type="bank")
+    database.session.add(reconciliation)
+    database.session.flush()
+
+    recon_item = ReconciliationItem(
+        reconciliation_id=reconciliation.id,
+        reference_type="bank_transaction",
+        reference_id=transaction.id,
+        source_type="bank_transaction",
+        source_id=transaction.id,
+        target_type="payment_entry",
+        target_id=payment.id,
+        amount=Decimal("100.00"),
+        allocated_amount=Decimal("100.00"),
+        status="reconciled",
+    )
+    database.session.add(recon_item)
+    database.session.commit()
+
+    # Before cancellation, the report should sum the 100.00 amount
+    report_before = get_reconciliation_report(company="cacao")
+    assert report_before.totals["bank_reconciled_amount"] == Decimal("100.00")
+
+    # Cancel the payment, which triggers marking status as 'cancelled'
+    _apply_payment_cancellation_hooks(payment)
+    database.session.commit()
+
+    # Verify that the ReconciliationItem status was updated to 'cancelled'
+    database.session.refresh(recon_item)
+    assert recon_item.status == "cancelled"
+
+    # After cancellation, the report should exclude the item, meaning bank_reconciled_amount is 0
+    report_after = get_reconciliation_report(company="cacao")
+    assert report_after.totals["bank_reconciled_amount"] == Decimal("0")


### PR DESCRIPTION
Filters out cancelled reconciliation items in the bank reconciliation report's query and bank_reconciled_amount calculation. Adds a unit test to cover this scenario.

---
*PR created automatically by Jules for task [9177485082189764729](https://jules.google.com/task/9177485082189764729) started by @williamjmorenor*