### PR TITLE
Fix currency mixing in semantic receivables and payables analysis datasets

### DIFF
--- a/cacao_accounting/reportes/semantic.py
+++ b/cacao_accounting/reportes/semantic.py
@@ -54,6 +54,34 @@ def _base_amount(line: Any, document: Any) -> Decimal:
     return _signed(amount, document)
 
 
+def _document_base_factor(document: Any) -> Decimal:
+    """Get the historical exchange rate factor for the document."""
+    original = _decimal(getattr(document, "grand_total", None) or getattr(document, "total", None))
+    base_value = getattr(document, "base_grand_total", None)
+    if base_value is None:
+        base_value = getattr(document, "base_total", None)
+    if base_value is not None and original != 0:
+        return _decimal(base_value) / original
+    rate = _decimal(getattr(document, "exchange_rate", None))
+    return rate if rate > 0 else Decimal("1")
+
+
+def _document_base_amount(document: Any) -> Decimal:
+    """Resolve the document amount in base currency with legacy fallbacks."""
+    amount = getattr(document, "base_grand_total", None) or getattr(document, "base_total", None)
+    if amount is None:
+        amount = _decimal(getattr(document, "grand_total", None) or getattr(document, "total", None)) * _decimal(
+            getattr(document, "exchange_rate", None) or 1
+        )
+    return _signed(amount, document)
+
+
+def _document_base_outstanding_amount(document: Any) -> Decimal:
+    """Resolve the live outstanding document amount in base currency."""
+    outstanding = compute_outstanding_amount(document)
+    return _signed(outstanding * _document_base_factor(document), document)
+
+
 def _bounded(query: Any, limit: int | None, offset: int | None) -> Any:
     if offset is not None:
         query = query.offset(max(offset, 0))
@@ -162,6 +190,9 @@ def get_receivables_analysis(
             "customer_code": invoice.customer_id,
             "amount": _signed(invoice.grand_total or invoice.total, invoice),
             "outstanding_amount": _signed(compute_outstanding_amount(invoice), invoice),
+            "currency": invoice.transaction_currency or invoice.base_currency,
+            "base_amount": _document_base_amount(invoice),
+            "base_outstanding_amount": _document_base_outstanding_amount(invoice),
         }
         for invoice in database.session.execute(query).scalars().all()
     ]
@@ -191,6 +222,9 @@ def get_payables_analysis(
             "supplier_code": invoice.supplier_id,
             "amount": _signed(invoice.grand_total or invoice.total, invoice),
             "outstanding_amount": _signed(compute_outstanding_amount(invoice), invoice),
+            "currency": invoice.transaction_currency or invoice.base_currency,
+            "base_amount": _document_base_amount(invoice),
+            "base_outstanding_amount": _document_base_outstanding_amount(invoice),
         }
         for invoice in database.session.execute(query).scalars().all()
     ]

--- a/cacao_accounting/reportes/semantic.py
+++ b/cacao_accounting/reportes/semantic.py
@@ -174,6 +174,11 @@ def get_receivables_analysis(
     offset: int | None = None,
 ) -> list[dict[str, Any]]:
     """Return one row per posted customer invoice with live outstanding value."""
+    from cacao_accounting.database import Entity
+
+    entities = database.session.execute(select(Entity)).scalars().all()
+    company_currencies = {e.code: e.currency for e in entities}
+
     query = select(SalesInvoice).where(SalesInvoice.docstatus == 1)
     if company:
         query = query.where(SalesInvoice.company == company)
@@ -190,7 +195,7 @@ def get_receivables_analysis(
             "customer_code": invoice.customer_id,
             "amount": _signed(invoice.grand_total or invoice.total, invoice),
             "outstanding_amount": _signed(compute_outstanding_amount(invoice), invoice),
-            "currency": invoice.transaction_currency or invoice.base_currency,
+            "currency": invoice.transaction_currency or invoice.base_currency or company_currencies.get(invoice.company),
             "base_amount": _document_base_amount(invoice),
             "base_outstanding_amount": _document_base_outstanding_amount(invoice),
         }
@@ -206,6 +211,11 @@ def get_payables_analysis(
     offset: int | None = None,
 ) -> list[dict[str, Any]]:
     """Return one row per posted supplier invoice with live outstanding value."""
+    from cacao_accounting.database import Entity
+
+    entities = database.session.execute(select(Entity)).scalars().all()
+    company_currencies = {e.code: e.currency for e in entities}
+
     query = select(PurchaseInvoice).where(PurchaseInvoice.docstatus == 1)
     if company:
         query = query.where(PurchaseInvoice.company == company)
@@ -222,7 +232,7 @@ def get_payables_analysis(
             "supplier_code": invoice.supplier_id,
             "amount": _signed(invoice.grand_total or invoice.total, invoice),
             "outstanding_amount": _signed(compute_outstanding_amount(invoice), invoice),
-            "currency": invoice.transaction_currency or invoice.base_currency,
+            "currency": invoice.transaction_currency or invoice.base_currency or company_currencies.get(invoice.company),
             "base_amount": _document_base_amount(invoice),
             "base_outstanding_amount": _document_base_outstanding_amount(invoice),
         }

--- a/tests/test_record_to_reports_multicurrency_multiledger.py
+++ b/tests/test_record_to_reports_multicurrency_multiledger.py
@@ -377,3 +377,125 @@ def test_cash_forecast_uses_base_legacy_balance_and_nets_returns():
     ]
 
     assert _sum_invoice_amount(invoices, date(2026, 8, 1), date(2026, 8, 31)) == Decimal("288")
+
+
+def test_semantic_reports_multicurrency(app_ctx):
+    """Verify that semantic AR/AP datasets correctly project currency, base_amount, and base_outstanding_amount."""
+    from cacao_accounting.database import (
+        PurchaseInvoice,
+        PurchaseInvoiceItem,
+        SalesInvoice,
+        SalesInvoiceItem,
+        database,
+    )
+    from cacao_accounting.reportes.semantic import (
+        get_payables_analysis,
+        get_receivables_analysis,
+    )
+
+    def make_sales_invoice(amount, currency, rate):
+        invoice = SalesInvoice(
+            company="r2r",
+            posting_date=date(2026, 8, 1),
+            customer_id="CUSTOMER-SEMANTIC",
+            transaction_currency=currency,
+            base_currency="NIO",
+            exchange_rate=rate,
+            grand_total=amount,
+            base_grand_total=amount * rate,
+            outstanding_amount=amount,
+            base_outstanding_amount=amount * rate,
+            is_return=False,
+            docstatus=1,
+        )
+        database.session.add(invoice)
+        database.session.flush()
+        database.session.add(
+            SalesInvoiceItem(
+                sales_invoice_id=invoice.id,
+                item_code="ITEM-SEMANTIC",
+                qty=1,
+                amount=amount,
+                base_amount=amount * rate,
+            )
+        )
+        return invoice
+
+    def make_purchase_invoice(amount, currency, rate):
+        invoice = PurchaseInvoice(
+            company="r2r",
+            posting_date=date(2026, 8, 1),
+            supplier_id="SUPPLIER-SEMANTIC",
+            transaction_currency=currency,
+            base_currency="NIO",
+            exchange_rate=rate,
+            grand_total=amount,
+            base_grand_total=amount * rate,
+            outstanding_amount=amount,
+            base_outstanding_amount=amount * rate,
+            is_return=False,
+            docstatus=1,
+        )
+        database.session.add(invoice)
+        database.session.flush()
+        database.session.add(
+            PurchaseInvoiceItem(
+                purchase_invoice_id=invoice.id,
+                item_code="ITEM-SEMANTIC",
+                qty=1,
+                amount=amount,
+                base_amount=amount * rate,
+            )
+        )
+        return invoice
+
+    # Clear previous documents for clean assertion
+    database.session.execute(database.delete(SalesInvoiceItem))
+    database.session.execute(database.delete(SalesInvoice))
+    database.session.execute(database.delete(PurchaseInvoiceItem))
+    database.session.execute(database.delete(PurchaseInvoice))
+    database.session.commit()
+
+    # Sales Invoices: 10 USD (base NIO 360) and 100 NIO (base NIO 100)
+    make_sales_invoice(Decimal("10"), "USD", Decimal("36"))
+    make_sales_invoice(Decimal("100"), "NIO", Decimal("1"))
+    database.session.commit()
+
+    receivables = get_receivables_analysis(company="r2r")
+    assert len(receivables) == 2
+
+    # Check first invoice (USD 10)
+    row_usd = [r for r in receivables if r["currency"] == "USD"][0]
+    assert row_usd["amount"] == Decimal("10")
+    assert row_usd["outstanding_amount"] == Decimal("10")
+    assert row_usd["base_amount"] == Decimal("360")
+    assert row_usd["base_outstanding_amount"] == Decimal("360")
+
+    # Check second invoice (NIO 100)
+    row_nio = [r for r in receivables if r["currency"] == "NIO"][0]
+    assert row_nio["amount"] == Decimal("100")
+    assert row_nio["outstanding_amount"] == Decimal("100")
+    assert row_nio["base_amount"] == Decimal("100")
+    assert row_nio["base_outstanding_amount"] == Decimal("100")
+
+    # Purchase Invoices: 10 USD (base NIO 360) and 100 NIO (base NIO 100)
+    make_purchase_invoice(Decimal("10"), "USD", Decimal("36"))
+    make_purchase_invoice(Decimal("100"), "NIO", Decimal("1"))
+    database.session.commit()
+
+    payables = get_payables_analysis(company="r2r")
+    assert len(payables) == 2
+
+    # Check first invoice (USD 10)
+    row_p_usd = [r for r in payables if r["currency"] == "USD"][0]
+    assert row_p_usd["amount"] == Decimal("10")
+    assert row_p_usd["outstanding_amount"] == Decimal("10")
+    assert row_p_usd["base_amount"] == Decimal("360")
+    assert row_p_usd["base_outstanding_amount"] == Decimal("360")
+
+    # Check second invoice (NIO 100)
+    row_p_nio = [r for r in payables if r["currency"] == "NIO"][0]
+    assert row_p_nio["amount"] == Decimal("100")
+    assert row_p_nio["outstanding_amount"] == Decimal("100")
+    assert row_p_nio["base_amount"] == Decimal("100")
+    assert row_p_nio["base_outstanding_amount"] == Decimal("100")

--- a/tests/test_record_to_reports_multicurrency_multiledger.py
+++ b/tests/test_record_to_reports_multicurrency_multiledger.py
@@ -399,12 +399,12 @@ def test_semantic_reports_multicurrency(app_ctx):
             posting_date=date(2026, 8, 1),
             customer_id="CUSTOMER-SEMANTIC",
             transaction_currency=currency,
-            base_currency="NIO",
+            base_currency="NIO" if currency else None,
             exchange_rate=rate,
             grand_total=amount,
-            base_grand_total=amount * rate,
+            base_grand_total=amount * rate if rate else None,
             outstanding_amount=amount,
-            base_outstanding_amount=amount * rate,
+            base_outstanding_amount=amount * rate if rate else None,
             is_return=False,
             docstatus=1,
         )
@@ -416,7 +416,7 @@ def test_semantic_reports_multicurrency(app_ctx):
                 item_code="ITEM-SEMANTIC",
                 qty=1,
                 amount=amount,
-                base_amount=amount * rate,
+                base_amount=amount * rate if rate else amount,
             )
         )
         return invoice
@@ -427,12 +427,12 @@ def test_semantic_reports_multicurrency(app_ctx):
             posting_date=date(2026, 8, 1),
             supplier_id="SUPPLIER-SEMANTIC",
             transaction_currency=currency,
-            base_currency="NIO",
+            base_currency="NIO" if currency else None,
             exchange_rate=rate,
             grand_total=amount,
-            base_grand_total=amount * rate,
+            base_grand_total=amount * rate if rate else None,
             outstanding_amount=amount,
-            base_outstanding_amount=amount * rate,
+            base_outstanding_amount=amount * rate if rate else None,
             is_return=False,
             docstatus=1,
         )
@@ -444,7 +444,7 @@ def test_semantic_reports_multicurrency(app_ctx):
                 item_code="ITEM-SEMANTIC",
                 qty=1,
                 amount=amount,
-                base_amount=amount * rate,
+                base_amount=amount * rate if rate else amount,
             )
         )
         return invoice
@@ -456,13 +456,14 @@ def test_semantic_reports_multicurrency(app_ctx):
     database.session.execute(database.delete(PurchaseInvoice))
     database.session.commit()
 
-    # Sales Invoices: 10 USD (base NIO 360) and 100 NIO (base NIO 100)
+    # Sales Invoices: 10 USD (base NIO 360), 100 NIO (base NIO 100) and 50 Untagged (no currencies set, company currency is NIO)
     make_sales_invoice(Decimal("10"), "USD", Decimal("36"))
     make_sales_invoice(Decimal("100"), "NIO", Decimal("1"))
+    make_sales_invoice(Decimal("50"), None, None)
     database.session.commit()
 
     receivables = get_receivables_analysis(company="r2r")
-    assert len(receivables) == 2
+    assert len(receivables) == 3
 
     # Check first invoice (USD 10)
     row_usd = [r for r in receivables if r["currency"] == "USD"][0]
@@ -472,19 +473,27 @@ def test_semantic_reports_multicurrency(app_ctx):
     assert row_usd["base_outstanding_amount"] == Decimal("360")
 
     # Check second invoice (NIO 100)
-    row_nio = [r for r in receivables if r["currency"] == "NIO"][0]
+    row_nio = [r for r in receivables if r["currency"] == "NIO" and r["amount"] == Decimal("100")][0]
     assert row_nio["amount"] == Decimal("100")
     assert row_nio["outstanding_amount"] == Decimal("100")
     assert row_nio["base_amount"] == Decimal("100")
     assert row_nio["base_outstanding_amount"] == Decimal("100")
 
-    # Purchase Invoices: 10 USD (base NIO 360) and 100 NIO (base NIO 100)
+    # Check untagged invoice (50) - should fall back to company currency (NIO)
+    row_untagged = [r for r in receivables if r["amount"] == Decimal("50")][0]
+    assert row_untagged["currency"] == "NIO"
+    assert row_untagged["outstanding_amount"] == Decimal("50")
+    assert row_untagged["base_amount"] == Decimal("50")
+    assert row_untagged["base_outstanding_amount"] == Decimal("50")
+
+    # Purchase Invoices: 10 USD (base NIO 360), 100 NIO (base NIO 100) and 50 Untagged (no currencies set, company currency is NIO)
     make_purchase_invoice(Decimal("10"), "USD", Decimal("36"))
     make_purchase_invoice(Decimal("100"), "NIO", Decimal("1"))
+    make_purchase_invoice(Decimal("50"), None, None)
     database.session.commit()
 
     payables = get_payables_analysis(company="r2r")
-    assert len(payables) == 2
+    assert len(payables) == 3
 
     # Check first invoice (USD 10)
     row_p_usd = [r for r in payables if r["currency"] == "USD"][0]
@@ -494,8 +503,15 @@ def test_semantic_reports_multicurrency(app_ctx):
     assert row_p_usd["base_outstanding_amount"] == Decimal("360")
 
     # Check second invoice (NIO 100)
-    row_p_nio = [r for r in payables if r["currency"] == "NIO"][0]
+    row_p_nio = [r for r in payables if r["currency"] == "NIO" and r["amount"] == Decimal("100")][0]
     assert row_p_nio["amount"] == Decimal("100")
     assert row_p_nio["outstanding_amount"] == Decimal("100")
     assert row_p_nio["base_amount"] == Decimal("100")
     assert row_p_nio["base_outstanding_amount"] == Decimal("100")
+
+    # Check untagged invoice (50) - should fall back to company currency (NIO)
+    row_p_untagged = [r for r in payables if r["amount"] == Decimal("50")][0]
+    assert row_p_untagged["currency"] == "NIO"
+    assert row_p_untagged["outstanding_amount"] == Decimal("50")
+    assert row_p_untagged["base_amount"] == Decimal("50")
+    assert row_p_untagged["base_outstanding_amount"] == Decimal("50")


### PR DESCRIPTION
Resolves RPT-AUDIT-06 [MEDIO] where get_receivables_analysis and get_payables_analysis were delivering transaction amounts without currency codes, leading to mixed currency aggregation bugs in BI adapters. We have successfully exposed currency and base_amount / base_outstanding_amount fields in both datasets and covered them with robust tests.

---
*PR created automatically by Jules for task [2854792244948962664](https://jules.google.com/task/2854792244948962664) started by @williamjmorenor*