### PR TITLE
Fix return quantity signing in sales/purchase semantic datasets (RPT-AUDIT-03)

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -2217,3 +2217,13 @@ Reconstruir la valoración de inventario en la fecha de corte (`date_to`) a part
   conciliación bancaria y varianza parcial quedaron ejecutables y pasaron.
 - Verificación final: `1641 passed, 8 skipped, 174 warnings` con el comando
   completo de pytest del proyecto.
+
+## 2026-08-11 — Dataset semántico de ventas y compras con signo en cantidad
+
+### Petición
+RPT-AUDIT-03 [MEDIO] — Datasets semánticos de ventas/compras no signan la quantity de devoluciones (solo el importe)
+
+### Implementación
+- Se modificó `cacao_accounting/reportes/semantic.py` para aplicar la función helper `_signed(line.qty, invoice)` en el campo `quantity` tanto para ventas (`get_sales_analysis`) como para compras (`get_purchase_analysis`).
+- Se amplió la prueba unitaria existente `test_semantic_reports_net_returns_and_expose_base_amount` en `tests/test_record_to_reports_multicurrency_multiledger.py` para verificar que la suma de las cantidades neteada con las devoluciones sea correcta (por ejemplo, esperado `0` para ventas y `1` para compras).
+- Calidad: Black, Ruff, Flake8 y mypy pasaron sin observaciones. Las pruebas unitarias fueron ejecutadas y pasaron exitosamente.

--- a/cacao_accounting/reportes/semantic.py
+++ b/cacao_accounting/reportes/semantic.py
@@ -92,7 +92,7 @@ def get_sales_analysis(
             "company_code": invoice.company,
             "customer_code": invoice.customer_id,
             "item_code": line.item_code,
-            "quantity": _decimal(line.qty),
+            "quantity": _signed(line.qty, invoice),
             "amount": _signed(line.amount, invoice),
             "base_amount": _base_amount(line, invoice),
         }
@@ -130,7 +130,7 @@ def get_purchase_analysis(
             "company_code": invoice.company,
             "supplier_code": invoice.supplier_id,
             "item_code": line.item_code,
-            "quantity": _decimal(line.qty),
+            "quantity": _signed(line.qty, invoice),
             "amount": _signed(line.amount, invoice),
             "base_amount": _base_amount(line, invoice),
         }

--- a/tests/test_record_to_reports_multicurrency_multiledger.py
+++ b/tests/test_record_to_reports_multicurrency_multiledger.py
@@ -345,8 +345,10 @@ def test_semantic_reports_net_returns_and_expose_base_amount(app_ctx):
     receivables = get_receivables_analysis(company="r2r")
     payables = get_payables_analysis(company="r2r")
 
+    assert sum(row["quantity"] for row in sales) == Decimal("0")
     assert sum(row["amount"] for row in sales) == Decimal("8")
     assert sum(row["base_amount"] for row in sales) == Decimal("288")
+    assert sum(row["quantity"] for row in purchases) == Decimal("1")
     assert sum(row["amount"] for row in purchases) == Decimal("15")
     assert sum(row["base_amount"] for row in purchases) == Decimal("540")
     assert sum(row["outstanding_amount"] for row in receivables) == Decimal("8")


### PR DESCRIPTION
We fixed RPT-AUDIT-03 by signing the quantity of returns in both sales and purchase semantic datasets (semantic.py) using the existing `_signed` helper. We also enhanced the corresponding test case in test_record_to_reports_multicurrency_multiledger.py to verify correct net totals.

---
*PR created automatically by Jules for task [4841967771742494027](https://jules.google.com/task/4841967771742494027) started by @williamjmorenor*