### PR TITLE
Correct backdated inventory turnover calculation

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -3,6 +3,18 @@
 > Este archivo documenta decisiones de diseño, arquitectura y hitos clave del proyecto.
 > Para detalles de implementación por sesión, consultar el historial de git.
 
+## 2026-08-11 — Corrección de Rotación de Inventario para Movimientos Retroactivos (RPT-AUDIT-02)
+
+### Petición
+
+La función `get_inventory_turnover` promedia los snapshots almacenados de `qty_after_transaction` para estimar el stock promedio. Este campo se volvía obsoleto con movimientos retroactivos y además el cálculo excluía el stock inicial del período.
+
+### Implementación
+
+- Se modificó `get_inventory_turnover` en `cacao_accounting/reportes/services.py` para reconstruir el stock promedio cronológicamente desde el stock ledger ordenado por `posting_date`, `created`, `id` (mismo criterio que `get_kardex`).
+- Se incluyó el stock inicial del período dentro del promedio, inicializando la secuencia de observaciones con el stock anterior a `date_from`.
+- Se añadió la prueba unitaria `test_get_inventory_turnover_with_backdated_transaction` en `tests/test_operational_report_framework.py` para verificar que el stock promedio y la tasa de rotación coincidan exactamente con la reconstrucción cronológica ante transacciones retroactivas.
+
 ## 2026-08-11 — Reejecución de revalorización cambiaria en pre-release
 
 - Se eliminó la unicidad artificial por compañía/período de `ExchangeRevaluation`.

--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -13,7 +13,8 @@ La función `get_inventory_turnover` promedia los snapshots almacenados de `qty_
 
 - Se modificó `get_inventory_turnover` en `cacao_accounting/reportes/services.py` para reconstruir el stock promedio cronológicamente desde el stock ledger ordenado por `posting_date`, `created`, `id` (mismo criterio que `get_kardex`).
 - Se incluyó el stock inicial del período dentro del promedio, inicializando la secuencia de observaciones con el stock anterior a `date_from`.
-- Se añadió la prueba unitaria `test_get_inventory_turnover_with_backdated_transaction` en `tests/test_operational_report_framework.py` para verificar que el stock promedio y la tasa de rotación coincidan exactamente con la reconstrucción cronológica ante transacciones retroactivas.
+- Se adaptó la reconstrucción cronológica para tratar las entradas de conciliación de inventario (`stock_reconciliation`) como objetivos absolutos (`counted_qty`). De esta manera, si una conciliación fue posteada retroactivamente, el replay cronológico recalcula correctamente el delta de cantidad en ese momento, logrando un promedio de stock y una tasa de rotación sumamente precisos.
+- Se añadió la prueba unitaria `test_get_inventory_turnover_with_backdated_transaction_and_reconciliation` en `tests/test_operational_report_framework.py` para verificar que el stock promedio, la cantidad saliente y la tasa de rotación coincidan exactamente con la reconstrucción cronológica ante transacciones retroactivas y conciliaciones retroactivas.
 
 ## 2026-08-11 — Reejecución de revalorización cambiaria en pre-release
 

--- a/cacao_accounting/reportes/services.py
+++ b/cacao_accounting/reportes/services.py
@@ -1019,40 +1019,57 @@ def get_slow_moving_items(
 
 
 def get_inventory_turnover(filters: OperationalReportFilters) -> PaginatedReport:
-    """Calcula rotación por artículo/almacén como salidas sobre stock promedio."""
+    """Calcula rotación por artículo/almacén como salidas sobre stock promedio reconstruido de forma cronológica."""
     if not filters.date_from or not filters.date_to or filters.date_to < filters.date_from:
         raise ValueError("date_from y date_to válidos son obligatorios para calcular rotación")
     query = exclude_cancelled_stock_entries(select(StockLedgerEntry)).where(
         StockLedgerEntry.company == filters.company,
-        StockLedgerEntry.posting_date >= filters.date_from,
         StockLedgerEntry.posting_date <= filters.date_to,
     )
     if filters.item_code:
         query = query.where(StockLedgerEntry.item_code == filters.item_code)
     if filters.warehouse:
         query = query.where(StockLedgerEntry.warehouse == filters.warehouse)
-    grouped: dict[tuple[str, str], dict[str, Decimal]] = defaultdict(
-        lambda: {"outgoing_qty": Decimal("0"), "stock_sum": Decimal("0"), "observations": Decimal("0")}
-    )
-    for entry in database.session.execute(query).scalars():
+
+    running_balances: dict[tuple[str, str], Decimal] = defaultdict(Decimal)
+    keys_with_activity: set[tuple[str, str]] = set()
+    stock_observations: dict[tuple[str, str], list[Decimal]] = defaultdict(list)
+    outgoing_quantities: dict[tuple[str, str], Decimal] = defaultdict(Decimal)
+    initial_stock_recorded: dict[tuple[str, str], bool] = defaultdict(bool)
+
+    for entry in database.session.execute(
+        query.order_by(StockLedgerEntry.posting_date, StockLedgerEntry.created, StockLedgerEntry.id)
+    ).scalars():
         key = (entry.item_code, entry.warehouse)
-        values = grouped[key]
-        qty = _decimal_value(entry.qty_change)
-        if qty < 0:
-            values["outgoing_qty"] += abs(qty)
-        values["stock_sum"] += max(_decimal_value(entry.qty_after_transaction), Decimal("0"))
-        values["observations"] += Decimal("1")
+        qty_change = _decimal_value(entry.qty_change)
+
+        if entry.posting_date < filters.date_from:
+            running_balances[key] += qty_change
+        else:
+            keys_with_activity.add(key)
+            if not initial_stock_recorded[key]:
+                stock_observations[key].append(max(running_balances[key], Decimal("0")))
+                initial_stock_recorded[key] = True
+
+            running_balances[key] += qty_change
+            stock_observations[key].append(max(running_balances[key], Decimal("0")))
+
+            if qty_change < 0:
+                outgoing_quantities[key] += abs(qty_change)
+
     rows = []
-    for (item_code, warehouse), values in sorted(grouped.items()):
-        average_stock = values["stock_sum"] / values["observations"] if values["observations"] else Decimal("0")
+    for item_code, warehouse in sorted(keys_with_activity):
+        observations = stock_observations[(item_code, warehouse)]
+        outgoing_qty = outgoing_quantities[(item_code, warehouse)]
+        average_stock = sum(observations, Decimal("0")) / len(observations) if observations else Decimal("0")
         rows.append(
             ReportRow(
                 values={
                     "item_code": item_code,
                     "warehouse": warehouse,
-                    "outgoing_qty": values["outgoing_qty"],
+                    "outgoing_qty": outgoing_qty,
                     "average_stock_qty": average_stock,
-                    "turnover_ratio": values["outgoing_qty"] / average_stock if average_stock else None,
+                    "turnover_ratio": outgoing_qty / average_stock if average_stock else None,
                 }
             )
         )

--- a/cacao_accounting/reportes/services.py
+++ b/cacao_accounting/reportes/services.py
@@ -1037,11 +1037,33 @@ def get_inventory_turnover(filters: OperationalReportFilters) -> PaginatedReport
     outgoing_quantities: dict[tuple[str, str], Decimal] = defaultdict(Decimal)
     initial_stock_recorded: dict[tuple[str, str], bool] = defaultdict(bool)
 
+    # Caches to optimize DB queries for stock reconciliation entries
+    stock_entry_purposes: dict[str, str | None] = {}
+    reconciliation_counted_qty: dict[tuple[str, str], Decimal] = {}
+
     for entry in database.session.execute(
         query.order_by(StockLedgerEntry.posting_date, StockLedgerEntry.created, StockLedgerEntry.id)
     ).scalars():
         key = (entry.item_code, entry.warehouse)
         qty_change = _decimal_value(entry.qty_change)
+
+        if entry.voucher_type == "stock_entry":
+            purpose = stock_entry_purposes.get(entry.voucher_id)
+            if purpose is None and entry.voucher_id not in stock_entry_purposes:
+                se = database.session.get(StockEntry, entry.voucher_id)
+                purpose = se.purpose if se else None
+                stock_entry_purposes[entry.voucher_id] = purpose
+            if purpose == "stock_reconciliation":
+                cache_key = (entry.voucher_id, entry.item_code)
+                if cache_key not in reconciliation_counted_qty:
+                    sei = database.session.execute(
+                        select(StockEntryItem.counted_qty).where(
+                            StockEntryItem.stock_entry_id == entry.voucher_id, StockEntryItem.item_code == entry.item_code
+                        )
+                    ).scalar_one_or_none()
+                    reconciliation_counted_qty[cache_key] = _decimal_value(sei) if sei is not None else Decimal("0")
+                counted_qty = reconciliation_counted_qty[cache_key]
+                qty_change = counted_qty - running_balances[key]
 
         if entry.posting_date < filters.date_from:
             running_balances[key] += qty_change

--- a/tests/test_operational_report_framework.py
+++ b/tests/test_operational_report_framework.py
@@ -215,24 +215,50 @@ def test_operational_report_routes_render_without_breaking_financial_reports(app
     assert 'doctype: "bank_account"' not in accounting_html
 
 
-def test_get_inventory_turnover_with_backdated_transaction(app_ctx):
-    from cacao_accounting.database import Item, StockLedgerEntry, UOM, Warehouse, database
+def test_get_inventory_turnover_with_backdated_transaction_and_reconciliation(app_ctx):
+    from cacao_accounting.database import Item, StockLedgerEntry, UOM, Warehouse, StockEntry, StockEntryItem, database
     from cacao_accounting.reportes.services import OperationalReportFilters, get_inventory_turnover
 
     database.session.add_all(
         [
             UOM(code="EA", name="Each"),
-            Item(code="ITEM-TO", name="Item Turnover", item_type="goods", is_stock_item=True, default_uom="EA"),
-            Warehouse(code="WH-TO", name="Bodega Turnover", company="cacao"),
+            Item(code="ITEM-TOR", name="Item Turnover Recon", item_type="goods", is_stock_item=True, default_uom="EA"),
+            Warehouse(code="WH-TOR", name="Bodega Turnover Recon", company="cacao"),
         ]
     )
+    database.session.flush()
+
+    # Create a StockEntry representing the stock reconciliation
+    recon_entry = StockEntry(
+        id="RECON1",
+        company="cacao",
+        posting_date=date(2026, 5, 10),
+        purpose="stock_reconciliation",
+        docstatus=1,
+    )
+    database.session.add(recon_entry)
+    database.session.flush()
+
+    recon_item = StockEntryItem(
+        stock_entry_id="RECON1",
+        item_code="ITEM-TOR",
+        counted_qty=Decimal("12"),
+        target_stock_value=Decimal("120"),
+        qty_difference=Decimal("2"),
+        qty=Decimal("2"),
+        qty_in_base_uom=Decimal("2"),
+        uom="EA",
+    )
+    database.session.add(recon_item)
+    database.session.flush()
+
     database.session.add_all(
         [
             # May 1: Receipt of 10 units.
             StockLedgerEntry(
                 posting_date=date(2026, 5, 1),
-                item_code="ITEM-TO",
-                warehouse="WH-TO",
+                item_code="ITEM-TOR",
+                warehouse="WH-TOR",
                 company="cacao",
                 qty_change=Decimal("10"),
                 qty_after_transaction=Decimal("10"),
@@ -242,11 +268,12 @@ def test_get_inventory_turnover_with_backdated_transaction(app_ctx):
                 voucher_type="stock_entry",
                 voucher_id="STE-1",
             ),
-            # May 10: Sale of 6 units.
+            # May 15: Sale of 6 units. (This was posted before the retroactive reconciliation was inserted on May 10,
+            # so at posting time, current stock was 10. 10 - 6 = 4)
             StockLedgerEntry(
-                posting_date=date(2026, 5, 10),
-                item_code="ITEM-TO",
-                warehouse="WH-TO",
+                posting_date=date(2026, 5, 15),
+                item_code="ITEM-TOR",
+                warehouse="WH-TOR",
                 company="cacao",
                 qty_change=Decimal("-6"),
                 qty_after_transaction=Decimal("4"),
@@ -259,8 +286,8 @@ def test_get_inventory_turnover_with_backdated_transaction(app_ctx):
             # May 5 (inserted retroactive): Receipt of 5 units.
             StockLedgerEntry(
                 posting_date=date(2026, 5, 5),
-                item_code="ITEM-TO",
-                warehouse="WH-TO",
+                item_code="ITEM-TOR",
+                warehouse="WH-TOR",
                 company="cacao",
                 qty_change=Decimal("5"),
                 qty_after_transaction=Decimal("15"),
@@ -269,6 +296,23 @@ def test_get_inventory_turnover_with_backdated_transaction(app_ctx):
                 stock_value=Decimal("90"),
                 voucher_type="stock_entry",
                 voucher_id="STE-3",
+            ),
+            # May 10 (inserted retroactive stock reconciliation): counted_qty = 12.
+            # At posting time, StockBin actual_qty is 9 (after May 15 sale of 6 and retroactive May 5 receipt of 5:
+            # 10 + 5 - 6 = 9).
+            # So _create_stock_reconciliation_movement calculated qty_change as 12 - 9 = 3.
+            StockLedgerEntry(
+                posting_date=date(2026, 5, 10),
+                item_code="ITEM-TOR",
+                warehouse="WH-TOR",
+                company="cacao",
+                qty_change=Decimal("3"),  # 12 - 9
+                qty_after_transaction=Decimal("12"),
+                valuation_rate=Decimal("10"),
+                stock_value_difference=Decimal("30"),
+                stock_value=Decimal("120"),
+                voucher_type="stock_entry",
+                voucher_id="RECON1",
             ),
         ]
     )
@@ -284,17 +328,21 @@ def test_get_inventory_turnover_with_backdated_transaction(app_ctx):
 
     assert len(report.rows) == 1
     row = report.rows[0].values
-    assert row["item_code"] == "ITEM-TO"
-    assert row["warehouse"] == "WH-TO"
-    assert row["outgoing_qty"] == Decimal("6")
+    assert row["item_code"] == "ITEM-TOR"
+    assert row["warehouse"] == "WH-TOR"
 
     # Chronological snapshots:
-    # Initial: 0
-    # May 1: 10
-    # May 5: 15
-    # May 10: 9
-    # Sum: 0 + 10 + 15 + 9 = 34
-    # Observations count: 4
-    # Expected average: 34 / 4 = 8.5
-    assert row["average_stock_qty"] == Decimal("8.5")
-    assert row["turnover_ratio"] == Decimal("6") / Decimal("8.5")
+    # 1. Initial: 0
+    # 2. May 1: 10
+    # 3. May 5: 15
+    # 4. May 10: absolute reconciliation target = 12 (counted_qty)
+    #    (The chronological qty_change is calculated as 12 - 15 = -3. Since it is negative, it counts as an outflow!)
+    # 5. May 15: sale of 6. Balance: 12 - 6 = 6. (Since qty_change is -6, another outflow!)
+    # Total outgoing_qty: 3 (from recon) + 6 (from sale) = 9
+    # Observations: [0, 10, 15, 12, 6]
+    # Sum: 43
+    # Count: 5
+    # Expected average: 43 / 5 = 8.6
+    assert row["outgoing_qty"] == Decimal("9")
+    assert row["average_stock_qty"] == Decimal("8.6")
+    assert row["turnover_ratio"] == Decimal("9") / Decimal("8.6")

--- a/tests/test_operational_report_framework.py
+++ b/tests/test_operational_report_framework.py
@@ -213,3 +213,88 @@ def test_operational_report_routes_render_without_breaking_financial_reports(app
     assert accounting_response.status_code == 200
     assert 'doctype: "book"' in accounting_html
     assert 'doctype: "bank_account"' not in accounting_html
+
+
+def test_get_inventory_turnover_with_backdated_transaction(app_ctx):
+    from cacao_accounting.database import Item, StockLedgerEntry, UOM, Warehouse, database
+    from cacao_accounting.reportes.services import OperationalReportFilters, get_inventory_turnover
+
+    database.session.add_all(
+        [
+            UOM(code="EA", name="Each"),
+            Item(code="ITEM-TO", name="Item Turnover", item_type="goods", is_stock_item=True, default_uom="EA"),
+            Warehouse(code="WH-TO", name="Bodega Turnover", company="cacao"),
+        ]
+    )
+    database.session.add_all(
+        [
+            # May 1: Receipt of 10 units.
+            StockLedgerEntry(
+                posting_date=date(2026, 5, 1),
+                item_code="ITEM-TO",
+                warehouse="WH-TO",
+                company="cacao",
+                qty_change=Decimal("10"),
+                qty_after_transaction=Decimal("10"),
+                valuation_rate=Decimal("10"),
+                stock_value_difference=Decimal("100"),
+                stock_value=Decimal("100"),
+                voucher_type="stock_entry",
+                voucher_id="STE-1",
+            ),
+            # May 10: Sale of 6 units.
+            StockLedgerEntry(
+                posting_date=date(2026, 5, 10),
+                item_code="ITEM-TO",
+                warehouse="WH-TO",
+                company="cacao",
+                qty_change=Decimal("-6"),
+                qty_after_transaction=Decimal("4"),
+                valuation_rate=Decimal("10"),
+                stock_value_difference=Decimal("-60"),
+                stock_value=Decimal("40"),
+                voucher_type="stock_entry",
+                voucher_id="STE-2",
+            ),
+            # May 5 (inserted retroactive): Receipt of 5 units.
+            StockLedgerEntry(
+                posting_date=date(2026, 5, 5),
+                item_code="ITEM-TO",
+                warehouse="WH-TO",
+                company="cacao",
+                qty_change=Decimal("5"),
+                qty_after_transaction=Decimal("15"),
+                valuation_rate=Decimal("10"),
+                stock_value_difference=Decimal("50"),
+                stock_value=Decimal("90"),
+                voucher_type="stock_entry",
+                voucher_id="STE-3",
+            ),
+        ]
+    )
+    database.session.commit()
+
+    report = get_inventory_turnover(
+        OperationalReportFilters(
+            company="cacao",
+            date_from=date(2026, 5, 1),
+            date_to=date(2026, 5, 31),
+        )
+    )
+
+    assert len(report.rows) == 1
+    row = report.rows[0].values
+    assert row["item_code"] == "ITEM-TO"
+    assert row["warehouse"] == "WH-TO"
+    assert row["outgoing_qty"] == Decimal("6")
+
+    # Chronological snapshots:
+    # Initial: 0
+    # May 1: 10
+    # May 5: 15
+    # May 10: 9
+    # Sum: 0 + 10 + 15 + 9 = 34
+    # Observations count: 4
+    # Expected average: 34 / 4 = 8.5
+    assert row["average_stock_qty"] == Decimal("8.5")
+    assert row["turnover_ratio"] == Decimal("6") / Decimal("8.5")


### PR DESCRIPTION
This PR fixes the inventory turnover calculation (`get_inventory_turnover`) so that average stock is reconstructed chronologically from the stock ledger entries and the period's initial stock is included in the average. Previously, the calculation used stale `qty_after_transaction` snapshots which became obsolete with backdated transactions. We added a robust unit test to prevent regression.

---
*PR created automatically by Jules for task [16344155441995597614](https://jules.google.com/task/16344155441995597614) started by @williamjmorenor*