### PR TITLE
Fix get_settlement_analysis to exclude cancelled payments

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -3,6 +3,19 @@
 > Este archivo documenta decisiones de diseño, arquitectura y hitos clave del proyecto.
 > Para detalles de implementación por sesión, consultar el historial de git.
 
+## 2026-08-11 — Corrección de RPT-AUDIT-04: get_settlement_analysis cuenta aplicaciones de pagos CANCELADOS y sus referencias
+
+### Petición
+get_settlement_analysis une PaymentReference con PaymentEntry por payment_id sin filtrar PaymentEntry.docstatus == 1 (semantic.py:207-227). La cancelación de pago es append-only: bancos_pago_cancel marca docstatus=2 y revierte relaciones, pero no elimina los PaymentReference (bancos/__init__.py:2340-2393). El resto de reportes sí filtra docstatus == 1.
+
+### Implementación
+- Se modificó `get_settlement_analysis` en `cacao_accounting/reportes/semantic.py`.
+- Se importó `and_` de `sqlalchemy`.
+- Se actualizó el query para filtrar por `PaymentEntry.docstatus == 1`.
+- Se unió el query con `DocumentRelation` mediante un `outerjoin` y se aseguró que el estado de la relación es nulo o activo (`or_(DocumentRelation.id.is_(None), DocumentRelation.status == "active")`), lo que de forma limpia y robusta excluye aplicaciones de pago cuyas relaciones han sido canceladas o revertidas.
+- Se agregó el test unitario `test_settlement_analysis_ignores_cancelled_payments` en `tests/test_record_to_reports_multicurrency_multiledger.py` para verificar que, una vez cancelado el pago, `get_settlement_analysis` ya no devuelve la aplicación de pago cancelada.
+- Se ejecutaron las pruebas unitarias y análisis estático (Black, Ruff, Flake8, Mypy), asegurando cumplimiento de calidad al 100%.
+
 ## 2026-08-11 — Reejecución de revalorización cambiaria en pre-release
 
 - Se eliminó la unicidad artificial por compañía/período de `ExchangeRevaluation`.

--- a/cacao_accounting/reportes/semantic.py
+++ b/cacao_accounting/reportes/semantic.py
@@ -12,7 +12,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import or_, select
+from sqlalchemy import and_, or_, select
 
 from cacao_accounting.database import (
     AuditTrail,
@@ -204,7 +204,21 @@ def get_settlement_analysis(
     offset: int | None = None,
 ) -> list[dict[str, Any]]:
     """Return payment applications at their allocation grain (N:N safe)."""
-    query = select(PaymentReference, PaymentEntry).join(PaymentEntry, PaymentEntry.id == PaymentReference.payment_id)
+    query = (
+        select(PaymentReference, PaymentEntry)
+        .join(PaymentEntry, PaymentEntry.id == PaymentReference.payment_id)
+        .outerjoin(
+            DocumentRelation,
+            and_(
+                DocumentRelation.target_type == "payment_entry",
+                DocumentRelation.target_item_id == PaymentReference.id,
+            ),
+        )
+        .where(
+            PaymentEntry.docstatus == 1,
+            or_(DocumentRelation.id.is_(None), DocumentRelation.status == "active"),
+        )
+    )
     if company:
         query = query.where(
             PaymentEntry.company == company,

--- a/tests/test_record_to_reports_multicurrency_multiledger.py
+++ b/tests/test_record_to_reports_multicurrency_multiledger.py
@@ -377,3 +377,96 @@ def test_cash_forecast_uses_base_legacy_balance_and_nets_returns():
     ]
 
     assert _sum_invoice_amount(invoices, date(2026, 8, 1), date(2026, 8, 31)) == Decimal("288")
+
+
+def test_settlement_analysis_ignores_cancelled_payments(app_ctx):
+    """Test get_settlement_analysis filters out cancelled payments and reverted relations."""
+    from datetime import date
+    from decimal import Decimal
+    from cacao_accounting.database import (
+        PaymentEntry,
+        PaymentReference,
+        SalesInvoice,
+        database,
+    )
+    from cacao_accounting.reportes.semantic import get_settlement_analysis
+    from cacao_accounting.document_flow.service import create_document_relation, revert_relations_for_target
+
+    # Create a sales invoice
+    invoice = SalesInvoice(
+        company="r2r",
+        posting_date=date(2026, 8, 1),
+        customer_id="CUST-SEMANTIC-SETTLEMENT",
+        transaction_currency="USD",
+        exchange_rate=Decimal("36"),
+        grand_total=Decimal("100"),
+        base_grand_total=Decimal("3600"),
+        outstanding_amount=Decimal("100"),
+        base_outstanding_amount=Decimal("3600"),
+        docstatus=1,
+    )
+    database.session.add(invoice)
+    database.session.flush()
+
+    # Create a payment entry
+    payment = PaymentEntry(
+        company="r2r",
+        posting_date=date(2026, 8, 2),
+        payment_type="receive",
+        party_type="customer",
+        party_id="CUST-SEMANTIC-SETTLEMENT",
+        transaction_currency="USD",
+        exchange_rate=Decimal("36"),
+        received_amount=Decimal("100"),
+        base_received_amount=Decimal("3600"),
+        docstatus=1,
+    )
+    database.session.add(payment)
+    database.session.flush()
+
+    # Create a payment reference
+    reference = PaymentReference(
+        payment_id=payment.id,
+        party_type="customer",
+        party_id="CUST-SEMANTIC-SETTLEMENT",
+        reference_type="sales_invoice",
+        flow_source_type="sales_invoice",
+        reference_id=invoice.id,
+        reference_document_no=invoice.document_no or invoice.id,
+        total_amount=Decimal("100"),
+        outstanding_amount=Decimal("100"),
+        allocated_amount=Decimal("100"),
+        allocation_date=payment.posting_date,
+    )
+    database.session.add(reference)
+    database.session.flush()
+
+    # Create document relation
+    create_document_relation(
+        source_type="sales_invoice",
+        source_id=invoice.id,
+        source_item_id=None,
+        target_type="payment_entry",
+        target_id=payment.id,
+        target_item_id=reference.id,
+        qty=Decimal("1"),
+        uom=None,
+        rate=Decimal("100"),
+        amount=Decimal("100"),
+    )
+    database.session.commit()
+
+    # Query settlement analysis: should return the row
+    settlement = get_settlement_analysis(company="r2r")
+    assert len(settlement) == 1
+    assert settlement[0]["amount"] == Decimal("100")
+    assert settlement[0]["customer_code"] == "CUST-SEMANTIC-SETTLEMENT"
+
+    # Now cancel the payment: set docstatus to 2 and revert relations
+    payment.docstatus = 2
+    revert_relations_for_target("payment_entry", payment.id, reason="payment_cancelled")
+    database.session.commit()
+
+    # Query settlement analysis again: should be empty!
+    settlement_after_cancel = get_settlement_analysis(company="r2r")
+    assert len(settlement_after_cancel) == 0


### PR DESCRIPTION
get_settlement_analysis was counting cancelled payments because it lacked docstatus filtering. This fix adds the proper filters and ensures reverted relations are excluded.

---
*PR created automatically by Jules for task [9121001790151741420](https://jules.google.com/task/9121001790151741420) started by @williamjmorenor*