### PR TITLE
Group bank report totals by currency when multiple currencies exist

### DIFF
--- a/cacao_accounting/reportes/__init__.py
+++ b/cacao_accounting/reportes/__init__.py
@@ -224,6 +224,8 @@ def _column_label(column: str, ledger_currency: str | None) -> str:
 def _format_cell(column: str, value: object, ledger_currency: str | None) -> str:
     if value is None or value == "":
         return _EMPTY_CELL_VALUE
+    if isinstance(value, dict):
+        return " / ".join(f"{curr} {_format_number(val)}" for curr, val in value.items())
     if column in _MONEY_COLUMNS:
         return _format_number(value)
     if column == "posting_date" and isinstance(value, date):

--- a/cacao_accounting/reportes/services.py
+++ b/cacao_accounting/reportes/services.py
@@ -181,7 +181,7 @@ class PaginatedReport:
     """Reporte paginado simple."""
 
     rows: list[ReportRow]
-    totals: dict[str, Decimal]
+    totals: dict[str, Any]
     columns: list[str] | None = None
     total_rows: int = 0
     page: int = 1
@@ -1443,15 +1443,37 @@ def get_bank_movement_detail(filters: BankingFilters) -> PaginatedReport:
     )
     running_balance = _compute_running_balance(rows)
 
-    total_incoming = sum((_decimal_value(row.values.get("incoming_amount")) for row in rows), Decimal("0"))
-    total_outgoing = sum((_decimal_value(row.values.get("outgoing_amount")) for row in rows), Decimal("0"))
+    currencies: set[str] = {str(row.values.get("currency")) for row in rows if row.values.get("currency") is not None}
+
+    total_incoming: dict[str, Decimal] | Decimal
+    total_outgoing: dict[str, Decimal] | Decimal
+    total_running_balance: dict[str, Decimal] | Decimal
+
+    if len(currencies) > 1:
+        total_incoming = {curr: Decimal("0") for curr in currencies}
+        total_outgoing = {curr: Decimal("0") for curr in currencies}
+        for row in rows:
+            curr = row.values.get("currency")
+            if curr:
+                curr_str = str(curr)
+                total_incoming[curr_str] += _decimal_value(row.values.get("incoming_amount"))
+                total_outgoing[curr_str] += _decimal_value(row.values.get("outgoing_amount"))
+        total_running_balance = {curr: Decimal("0") for curr in currencies}
+        for curr in currencies:
+            total_running_balance[curr] = total_incoming[curr] - total_outgoing[curr]
+        for row in rows:
+            row.values["running_balance"] = None
+    else:
+        total_incoming = sum((_decimal_value(row.values.get("incoming_amount")) for row in rows), Decimal("0"))
+        total_outgoing = sum((_decimal_value(row.values.get("outgoing_amount")) for row in rows), Decimal("0"))
+        total_running_balance = running_balance
 
     return PaginatedReport(
         rows=rows,
         totals={
             "incoming_amount": total_incoming,
             "outgoing_amount": total_outgoing,
-            "running_balance": running_balance,
+            "running_balance": total_running_balance,
         },
         columns=[
             "posting_date",
@@ -1618,12 +1640,10 @@ def get_bank_balance_summary(filters: BankingFilters) -> PaginatedReport:
     bank_accounts = database.session.execute(bank_accounts_query.order_by(BankAccount.account_name.asc())).scalars().all()
 
     rows: list[ReportRow] = []
-    total_balance = Decimal("0")
     for bank_account in bank_accounts:
         balance = _compute_gl_balance(filters.company, bank_account.id, filters.as_of_date)
         receipts, payments = _compute_account_receipts_and_payments(bank_account.id, filters.company, filters.as_of_date)
 
-        total_balance += balance
         rows.append(
             ReportRow(
                 values={
@@ -1637,12 +1657,34 @@ def get_bank_balance_summary(filters: BankingFilters) -> PaginatedReport:
             )
         )
 
+    currencies: set[str] = {str(row.values.get("currency")) for row in rows if row.values.get("currency") is not None}
+
+    total_receipts: dict[str, Decimal] | Decimal
+    total_payments: dict[str, Decimal] | Decimal
+    total_ending: dict[str, Decimal] | Decimal
+
+    if len(currencies) > 1:
+        total_receipts = {curr: Decimal("0") for curr in currencies}
+        total_payments = {curr: Decimal("0") for curr in currencies}
+        total_ending = {curr: Decimal("0") for curr in currencies}
+        for row in rows:
+            curr = row.values.get("currency")
+            if curr:
+                curr_str = str(curr)
+                total_receipts[curr_str] += _decimal_value(row.values.get("receipts_amount"))
+                total_payments[curr_str] += _decimal_value(row.values.get("payments_amount"))
+                total_ending[curr_str] += _decimal_value(row.values.get("ending_balance"))
+    else:
+        total_receipts = sum((_decimal_value(row.values["receipts_amount"]) for row in rows), Decimal("0"))
+        total_payments = sum((_decimal_value(row.values["payments_amount"]) for row in rows), Decimal("0"))
+        total_ending = sum((_decimal_value(row.values["ending_balance"]) for row in rows), Decimal("0"))
+
     return PaginatedReport(
         rows=rows,
         totals={
-            "receipts_amount": sum((_decimal_value(row.values["receipts_amount"]) for row in rows), Decimal("0")),
-            "payments_amount": sum((_decimal_value(row.values["payments_amount"]) for row in rows), Decimal("0")),
-            "ending_balance": total_balance,
+            "receipts_amount": total_receipts,
+            "payments_amount": total_payments,
+            "ending_balance": total_ending,
         },
         columns=["bank_account", "account_no", "currency", "receipts_amount", "payments_amount", "ending_balance"],
     )

--- a/cacao_accounting/reportes/services.py
+++ b/cacao_accounting/reportes/services.py
@@ -11,7 +11,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 from typing import Any, Sequence, cast
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, case, func, or_, select
 
 from cacao_accounting.compras.purchase_reconciliation_service import get_purchase_reconciliation_pending
 from cacao_accounting.database import (
@@ -1620,8 +1620,14 @@ def _transfer_payment_amount(payment: PaymentEntry, bank_account_id: str) -> Dec
     return _decimal_value(payment.paid_amount)
 
 
-def _compute_gl_balance(company: str, bank_account_id: str, as_of_date: date | None) -> Decimal:
-    gl_balance_query = exclude_cancelled_gl_entries(select(func.coalesce(func.sum(GLEntry.debit - GLEntry.credit), 0))).where(
+def _compute_gl_balance(company: str, bank_account_id: str, bank_currency: str | None, as_of_date: date | None) -> Decimal:
+    account_debit = func.coalesce(GLEntry.debit_in_account_currency, GLEntry.debit)
+    account_credit = func.coalesce(GLEntry.credit_in_account_currency, GLEntry.credit)
+    balance_expression = case(
+        (GLEntry.account_currency == bank_currency, account_debit - account_credit),
+        else_=GLEntry.debit - GLEntry.credit,
+    )
+    gl_balance_query = exclude_cancelled_gl_entries(select(func.coalesce(func.sum(balance_expression), 0))).where(
         GLEntry.company == company,
         GLEntry.bank_account_id == bank_account_id,
     )
@@ -1642,7 +1648,7 @@ def get_bank_balance_summary(filters: BankingFilters) -> PaginatedReport:
 
     rows: list[ReportRow] = []
     for bank_account in bank_accounts:
-        balance = _compute_gl_balance(filters.company, bank_account.id, filters.as_of_date)
+        balance = _compute_gl_balance(filters.company, bank_account.id, bank_account.currency, filters.as_of_date)
         receipts, payments = _compute_account_receipts_and_payments(bank_account.id, filters.company, filters.as_of_date)
 
         rows.append(

--- a/cacao_accounting/reportes/services.py
+++ b/cacao_accounting/reportes/services.py
@@ -1243,6 +1243,7 @@ def _build_payment_row_values(
     party_names: dict[str, str],
 ) -> dict[str, object]:
     bank_account = bank_accounts.get(bank_account_id) if bank_account_id else None
+    currency = bank_account.currency if bank_account and bank_account.currency else payment.currency
     return {
         "posting_date": payment.posting_date,
         "document_no": payment.document_no or payment.id,
@@ -1253,7 +1254,7 @@ def _build_payment_row_values(
         "reference_no": payment.reference_no,
         "incoming_amount": incoming,
         "outgoing_amount": outgoing,
-        "currency": payment.currency,
+        "currency": currency,
         "status": "cancelled" if payment.docstatus == 2 else "submitted",
         "remarks": payment.remarks,
     }

--- a/tests/test_operational_report_framework.py
+++ b/tests/test_operational_report_framework.py
@@ -224,9 +224,13 @@ def test_multicurrency_bank_reports(app_ctx):
     database.session.flush()
 
     # Configure NIO account
-    account_nio = BankAccount(bank_id=bank.id, company="cacao", account_name="NIO Account", currency="NIO", account_no="NIO-123")
+    account_nio = BankAccount(
+        bank_id=bank.id, company="cacao", account_name="NIO Account", currency="NIO", account_no="NIO-123"
+    )
     # Configure USD account
-    account_usd = BankAccount(bank_id=bank.id, company="cacao", account_name="USD Account", currency="USD", account_no="USD-123")
+    account_usd = BankAccount(
+        bank_id=bank.id, company="cacao", account_name="USD Account", currency="USD", account_no="USD-123"
+    )
     database.session.add_all([account_nio, account_usd])
     database.session.flush()
 
@@ -251,6 +255,17 @@ def test_multicurrency_bank_reports(app_ctx):
                 currency="USD",
                 docstatus=1,
             ),
+            PaymentEntry(
+                company="cacao",
+                posting_date=date(2026, 5, 4),
+                payment_type="internal_transfer",
+                bank_account_id=account_usd.id,
+                target_bank_account_id=account_nio.id,
+                paid_amount=Decimal("100.00"),
+                received_amount=Decimal("3600.00"),
+                currency="USD",
+                docstatus=1,
+            ),
         ]
     )
     database.session.commit()
@@ -263,27 +278,25 @@ def test_multicurrency_bank_reports(app_ctx):
 
     # Verify totals are dictionaries grouped by currency
     assert isinstance(movement_report.totals["incoming_amount"], dict)
-    assert movement_report.totals["incoming_amount"]["NIO"] == Decimal("3600.00")
+    assert movement_report.totals["incoming_amount"]["NIO"] == Decimal("7200.00")
     assert movement_report.totals["incoming_amount"]["USD"] == Decimal("100.00")
     assert movement_report.totals["outgoing_amount"]["NIO"] == Decimal("0.00")
-    assert movement_report.totals["outgoing_amount"]["USD"] == Decimal("0.00")
-    assert movement_report.totals["running_balance"]["NIO"] == Decimal("3600.00")
-    assert movement_report.totals["running_balance"]["USD"] == Decimal("100.00")
+    assert movement_report.totals["outgoing_amount"]["USD"] == Decimal("100.00")
+    assert movement_report.totals["running_balance"]["NIO"] == Decimal("7200.00")
+    assert movement_report.totals["running_balance"]["USD"] == Decimal("0.00")
 
     # Verify that row-level running_balance is None for all rows since there are multiple currencies
     for row in movement_report.rows:
         assert row.values["running_balance"] is None
 
     # 2. Test get_bank_balance_summary
-    balance_report = get_bank_balance_summary(
-        BankingFilters(company="cacao", as_of_date=date(2026, 5, 31))
-    )
+    balance_report = get_bank_balance_summary(BankingFilters(company="cacao", as_of_date=date(2026, 5, 31)))
 
     # Verify totals are dictionaries grouped by currency
     assert isinstance(balance_report.totals["ending_balance"], dict)
-    assert balance_report.totals["receipts_amount"]["NIO"] == Decimal("3600.00")
+    assert balance_report.totals["receipts_amount"]["NIO"] == Decimal("7200.00")
     assert balance_report.totals["receipts_amount"]["USD"] == Decimal("100.00")
     assert balance_report.totals["payments_amount"]["NIO"] == Decimal("0.00")
-    assert balance_report.totals["payments_amount"]["USD"] == Decimal("0.00")
+    assert balance_report.totals["payments_amount"]["USD"] == Decimal("100.00")
     assert balance_report.totals["ending_balance"]["NIO"] == Decimal("0.00")
     assert balance_report.totals["ending_balance"]["USD"] == Decimal("0.00")

--- a/tests/test_operational_report_framework.py
+++ b/tests/test_operational_report_framework.py
@@ -213,3 +213,77 @@ def test_operational_report_routes_render_without_breaking_financial_reports(app
     assert accounting_response.status_code == 200
     assert 'doctype: "book"' in accounting_html
     assert 'doctype: "bank_account"' not in accounting_html
+
+
+def test_multicurrency_bank_reports(app_ctx):
+    from cacao_accounting.database import Bank, BankAccount, PaymentEntry, database
+    from cacao_accounting.reportes.services import BankingFilters, get_bank_movement_detail, get_bank_balance_summary
+
+    bank = Bank(name="Banco Multicurrency")
+    database.session.add(bank)
+    database.session.flush()
+
+    # Configure NIO account
+    account_nio = BankAccount(bank_id=bank.id, company="cacao", account_name="NIO Account", currency="NIO", account_no="NIO-123")
+    # Configure USD account
+    account_usd = BankAccount(bank_id=bank.id, company="cacao", account_name="USD Account", currency="USD", account_no="USD-123")
+    database.session.add_all([account_nio, account_usd])
+    database.session.flush()
+
+    # Add transactions
+    database.session.add_all(
+        [
+            PaymentEntry(
+                company="cacao",
+                posting_date=date(2026, 5, 2),
+                payment_type="receive",
+                bank_account_id=account_nio.id,
+                received_amount=Decimal("3600.00"),
+                currency="NIO",
+                docstatus=1,
+            ),
+            PaymentEntry(
+                company="cacao",
+                posting_date=date(2026, 5, 3),
+                payment_type="receive",
+                bank_account_id=account_usd.id,
+                received_amount=Decimal("100.00"),
+                currency="USD",
+                docstatus=1,
+            ),
+        ]
+    )
+    database.session.commit()
+
+    # 1. Test get_bank_movement_detail
+    # Call without account filter, so it includes both NIO and USD
+    movement_report = get_bank_movement_detail(
+        BankingFilters(company="cacao", date_from=date(2026, 5, 1), date_to=date(2026, 5, 31))
+    )
+
+    # Verify totals are dictionaries grouped by currency
+    assert isinstance(movement_report.totals["incoming_amount"], dict)
+    assert movement_report.totals["incoming_amount"]["NIO"] == Decimal("3600.00")
+    assert movement_report.totals["incoming_amount"]["USD"] == Decimal("100.00")
+    assert movement_report.totals["outgoing_amount"]["NIO"] == Decimal("0.00")
+    assert movement_report.totals["outgoing_amount"]["USD"] == Decimal("0.00")
+    assert movement_report.totals["running_balance"]["NIO"] == Decimal("3600.00")
+    assert movement_report.totals["running_balance"]["USD"] == Decimal("100.00")
+
+    # Verify that row-level running_balance is None for all rows since there are multiple currencies
+    for row in movement_report.rows:
+        assert row.values["running_balance"] is None
+
+    # 2. Test get_bank_balance_summary
+    balance_report = get_bank_balance_summary(
+        BankingFilters(company="cacao", as_of_date=date(2026, 5, 31))
+    )
+
+    # Verify totals are dictionaries grouped by currency
+    assert isinstance(balance_report.totals["ending_balance"], dict)
+    assert balance_report.totals["receipts_amount"]["NIO"] == Decimal("3600.00")
+    assert balance_report.totals["receipts_amount"]["USD"] == Decimal("100.00")
+    assert balance_report.totals["payments_amount"]["NIO"] == Decimal("0.00")
+    assert balance_report.totals["payments_amount"]["USD"] == Decimal("0.00")
+    assert balance_report.totals["ending_balance"]["NIO"] == Decimal("0.00")
+    assert balance_report.totals["ending_balance"]["USD"] == Decimal("0.00")

--- a/tests/test_operational_report_framework.py
+++ b/tests/test_operational_report_framework.py
@@ -216,11 +216,29 @@ def test_operational_report_routes_render_without_breaking_financial_reports(app
 
 
 def test_multicurrency_bank_reports(app_ctx):
-    from cacao_accounting.database import Bank, BankAccount, PaymentEntry, database
+    from cacao_accounting.database import (
+        Accounts,
+        Bank,
+        BankAccount,
+        Book,
+        GLEntry,
+        PaymentEntry,
+        database,
+    )
     from cacao_accounting.reportes.services import BankingFilters, get_bank_movement_detail, get_bank_balance_summary
 
     bank = Bank(name="Banco Multicurrency")
     database.session.add(bank)
+    database.session.flush()
+
+    bank_gl = Accounts(
+        entity="cacao",
+        code="1101-USD",
+        name="USD Bank GL",
+        classification="asset",
+        active=True,
+    )
+    database.session.add(bank_gl)
     database.session.flush()
 
     # Configure NIO account
@@ -229,7 +247,12 @@ def test_multicurrency_bank_reports(app_ctx):
     )
     # Configure USD account
     account_usd = BankAccount(
-        bank_id=bank.id, company="cacao", account_name="USD Account", currency="USD", account_no="USD-123"
+        bank_id=bank.id,
+        company="cacao",
+        account_name="USD Account",
+        currency="USD",
+        account_no="USD-123",
+        gl_account_id=bank_gl.id,
     )
     database.session.add_all([account_nio, account_usd])
     database.session.flush()
@@ -270,6 +293,25 @@ def test_multicurrency_bank_reports(app_ctx):
     )
     database.session.commit()
 
+    database.session.add(
+        GLEntry(
+            posting_date=date(2026, 5, 3),
+            company="cacao",
+            ledger_id=database.session.execute(database.select(Book.id).filter_by(entity="cacao", code="FISC")).scalar_one(),
+            account_id=bank_gl.id,
+            debit=Decimal("3600.00"),
+            credit=Decimal("0.00"),
+            debit_in_account_currency=Decimal("100.00"),
+            credit_in_account_currency=Decimal("0.00"),
+            account_currency="USD",
+            company_currency="NIO",
+            bank_account_id=account_usd.id,
+            voucher_type="test",
+            voucher_id="bank-balance-test",
+        )
+    )
+    database.session.commit()
+
     # 1. Test get_bank_movement_detail
     # Call without account filter, so it includes both NIO and USD
     movement_report = get_bank_movement_detail(
@@ -299,4 +341,4 @@ def test_multicurrency_bank_reports(app_ctx):
     assert balance_report.totals["payments_amount"]["NIO"] == Decimal("0.00")
     assert balance_report.totals["payments_amount"]["USD"] == Decimal("100.00")
     assert balance_report.totals["ending_balance"]["NIO"] == Decimal("0.00")
-    assert balance_report.totals["ending_balance"]["USD"] == Decimal("0.00")
+    assert balance_report.totals["ending_balance"]["USD"] == Decimal("100.00")


### PR DESCRIPTION
This pull request resolves RPT-AUDIT-07 where bank report totals incorrectly mix and sum values across different currencies. 

Key changes:
1. Updated `_format_cell` in `cacao_accounting/reportes/__init__.py` to cleanly format dictionary-based totals as a slash-separated list of localized amounts (e.g. `NIO 3,600.00 / USD 100.00`).
2. Updated `get_bank_movement_detail` and `get_bank_balance_summary` in `cacao_accounting/reportes/services.py` to check the number of unique currencies across rows. If multiple currencies are present, totals are grouped into dictionaries by currency.
3. Cleared individual row `running_balance` values when multiple currencies are mixed, as cross-currency sequential balance accumulation is mathematically undefined without conversion.
4. Added `test_multicurrency_bank_reports` unit test in `tests/test_operational_report_framework.py` to cover multicurrency bank report totals and row-level running balances. All checks and tests passed successfully.

---
*PR created automatically by Jules for task [8484298612778166630](https://jules.google.com/task/8484298612778166630) started by @williamjmorenor*