### PR TITLE
Include initial setup brand logo in package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -20,7 +20,6 @@ recursive-exclude cacao_accounting/query_tools/tests *
 recursive-exclude cacao_accounting/static/media/Linux *
 recursive-exclude cacao_accounting/static/media/Windows *
 recursive-exclude cacao_accounting/static/media/Web *
-exclude cacao_accounting/static/media/brand.svg
 exclude cacao_accounting/static/media/cacao_accounting _logo.png
 exclude cacao_accounting/static/media/cacao_logo.svg
 exclude cacao_accounting/static/media/Cacao Accounting SVG.svg


### PR DESCRIPTION
Removed the exclusion of `brand.svg` in `MANIFEST.in` to ensure that the initial setup screen's logo asset is correctly packaged and distributed when releasing to PyPI, thereby resolving the missing logo issue.

---
*PR created automatically by Jules for task [16430310797072515595](https://jules.google.com/task/16430310797072515595) started by @williamjmorenor*