### PR TITLE
Portales de Clientes y Proveedores para Modo Cloud

### DIFF
--- a/cacao_accounting/__init__.py
+++ b/cacao_accounting/__init__.py
@@ -63,6 +63,7 @@ from cacao_accounting.reportes import reportes
 from cacao_accounting.runtime_mode import force_single_entity, is_cloud_mode, is_desktop_mode
 from cacao_accounting.setup import setup_ as setup_wizard
 from cacao_accounting.ventas import ventas
+from cacao_accounting.portal import portal as portal_blueprint
 from cacao_accounting.version import PRERELEASE
 from flask_babel import Babel
 
@@ -180,6 +181,7 @@ def registrar_blueprints(app: Flask | None = None) -> None:
             app.register_blueprint(imports, url_prefix="/imports")
             app.register_blueprint(printing_public)
             app.register_blueprint(printing_admin)
+            app.register_blueprint(portal_blueprint, url_prefix="/portal")
             init_printing()
 
     else:

--- a/cacao_accounting/admin/__init__.py
+++ b/cacao_accounting/admin/__init__.py
@@ -959,6 +959,10 @@ def usuario_roles(user_id: str):
         flash(USUARIO_NO_ENCONTRADO, "danger")
         return redirect(url_for(LISTA_USUARIOS))
 
+    if usuario.classification in ("customer", "supplier"):
+        flash("Solo los usuarios de tipo 'system' pueden tener roles de acceso.", "warning")
+        return redirect(url_for(LISTA_USUARIOS))
+
     roles = _obtener_roles_disponibles()
     form = UserRoleForm()
     form.roles.choices = [(rol.id, rol.name) for rol in roles]

--- a/cacao_accounting/app/__init__.py
+++ b/cacao_accounting/app/__init__.py
@@ -32,6 +32,14 @@ cacao_app = Blueprint("cacao_app", __name__, template_folder="templates")
 @login_required
 def pagina_inicio():
     """Esta es la primer pagina mostrada al usuario luego de iniciar sesion."""
+    from flask import redirect
+    from flask_login import current_user
+
+    if current_user.is_portal_customer:
+        return redirect("/portal/customer")
+    if current_user.is_portal_supplier:
+        return redirect("/portal/supplier")
+
     entidades = database.session.query(Entity).order_by(Entity.name).all()
     periodos = database.session.query(AccountingPeriod).order_by(AccountingPeriod.start.desc()).all()
     dashboard_entities = [

--- a/cacao_accounting/auth/forms.py
+++ b/cacao_accounting/auth/forms.py
@@ -11,7 +11,7 @@
 # Librerias de terceros
 # ---------------------------------------------------------------------------------------
 from flask_wtf import FlaskForm
-from wtforms import BooleanField, PasswordField, SelectMultipleField, StringField, SubmitField
+from wtforms import BooleanField, PasswordField, SelectField, SelectMultipleField, StringField, SubmitField
 from wtforms.validators import DataRequired, Email, EqualTo, Length, Optional
 from wtforms.widgets import CheckboxInput, ListWidget
 
@@ -65,7 +65,12 @@ class UserCreateForm(FlaskForm):
     last_name2 = StringField(SEGUNDO_APELLIDO, validators=[Optional()])
     e_mail = StringField(CORREO_ELECTRONICO, validators=[Optional(), Email()])
     phone = StringField(TELEFONO, validators=[Optional()])
-    classification = StringField("Clasificación", validators=[Optional()])
+    classification = SelectField(
+        "Clasificación",
+        choices=[("system", "Sistema (System)"), ("customer", "Cliente (Customer)"), ("supplier", "Proveedor (Supplier)")],
+        validators=[DataRequired()],
+        default="system",
+    )
     active = BooleanField("Habilitado", default=True)
     password = PasswordField("Contraseña", validators=[DataRequired(), Length(min=8)])
     confirm_password = PasswordField(
@@ -85,7 +90,17 @@ class UserEditForm(FlaskForm):
     last_name2 = StringField(SEGUNDO_APELLIDO, validators=[Optional()])
     e_mail = StringField(CORREO_ELECTRONICO, validators=[Optional(), Email()])
     phone = StringField(TELEFONO, validators=[Optional()])
-    classification = StringField("Clasificación", validators=[Optional()])
+    classification = SelectField(
+        "Clasificación",
+        choices=[
+            ("system", "Sistema (System)"),
+            ("customer", "Cliente (Customer)"),
+            ("supplier", "Proveedor (Supplier)"),
+            ("admin", "Administrador (Admin)"),
+        ],
+        validators=[DataRequired()],
+        default="system",
+    )
     active = BooleanField("Habilitado")
     guardar_usuario = SubmitField("Guardar usuario")
 

--- a/cacao_accounting/auth/helpers.py
+++ b/cacao_accounting/auth/helpers.py
@@ -65,9 +65,11 @@ def validar_clave_segura(clave: str) -> bool:
 
 def puede_iniciar_en_escritorio(identidad: User) -> bool:
     """Determina si el usuario puede iniciar sesión en modo escritorio."""
-    if not is_desktop_mode():
-        return True
-    return identidad.classification == "admin"
+    if is_desktop_mode():
+        if identidad.is_portal_customer or identidad.is_portal_supplier:
+            return False
+        return identidad.classification == "admin"
+    return True
 
 
 def asignar_token_para_usuario(identidad: User) -> None:
@@ -100,5 +102,13 @@ def redireccion_despues_de_login():
     if setup_wizard and setup_wizard[0].value == "False":
         session["setup_step"] = 1
         return redirect(url_for("setup.setup"))
+
+    from flask_login import current_user
+
+    if current_user.is_authenticated:
+        if current_user.is_portal_customer:
+            return redirect("/portal/customer")
+        if current_user.is_portal_supplier:
+            return redirect("/portal/supplier")
 
     return redirect(url_for("cacao_app.pagina_inicio"))

--- a/cacao_accounting/auth/roles.py
+++ b/cacao_accounting/auth/roles.py
@@ -116,6 +116,16 @@ BUSINESS_ANALYST = {
     "detalle": "Analista de Negocios",
 }
 
+CUSTOMER = {
+    "name": "customer",
+    "detalle": "Portal de Cliente",
+}
+
+SUPPLIER = {
+    "name": "supplier",
+    "detalle": "Portal de Proveedor",
+}
+
 
 ROLES_PREDETERMINADOS = [
     ADMINISTRADOR,
@@ -136,7 +146,21 @@ ROLES_PREDETERMINADOS = [
     VENTAS_USER,
     COMPTROLLER,
     BUSINESS_ANALYST,
+    CUSTOMER,
+    SUPPLIER,
 ]
+
+
+def tiene_rol(user_id: str, role_name: str) -> bool:
+    """Verifica si un usuario tiene un rol determinado."""
+    from cacao_accounting.database import Roles, RolesUser, database
+
+    res = database.session.execute(
+        database.select(RolesUser.id)
+        .join(Roles, Roles.id == RolesUser.role_id)
+        .filter(RolesUser.user_id == user_id, Roles.name == role_name)
+    ).scalar_one_or_none()
+    return res is not None
 
 
 def crea_roles_predeterminados() -> None:

--- a/cacao_accounting/database/__init__.py
+++ b/cacao_accounting/database/__init__.py
@@ -302,6 +302,7 @@ class User(UserMixin, database.Model, BaseTabla):  # type: ignore[name-defined]
 
     @property
     def is_portal_customer(self) -> bool:
+        """Retorna verdadero si el usuario es de tipo cliente."""
         if self.classification == "customer":
             return True
         if not self.id:
@@ -312,6 +313,7 @@ class User(UserMixin, database.Model, BaseTabla):  # type: ignore[name-defined]
 
     @property
     def is_portal_supplier(self) -> bool:
+        """Retorna verdadero si el usuario es de tipo proveedor."""
         if self.classification == "supplier":
             return True
         if not self.id:

--- a/cacao_accounting/database/__init__.py
+++ b/cacao_accounting/database/__init__.py
@@ -296,6 +296,29 @@ class User(UserMixin, database.Model, BaseTabla):  # type: ignore[name-defined]
     genre = database.Column(database.String(10))
     birthday = database.Column(database.Date())
     phone = database.Column(database.String(50))
+    party_id = database.Column(
+        database.String(26), database.ForeignKey(PARTY_ID, ondelete=FK_SET_NULL, onupdate=FK_CASCADE), nullable=True
+    )
+
+    @property
+    def is_portal_customer(self) -> bool:
+        if self.classification == "customer":
+            return True
+        if not self.id:
+            return False
+        from cacao_accounting.auth.roles import tiene_rol
+
+        return tiene_rol(self.id, "customer")
+
+    @property
+    def is_portal_supplier(self) -> bool:
+        if self.classification == "supplier":
+            return True
+        if not self.id:
+            return False
+        from cacao_accounting.auth.roles import tiene_rol
+
+        return tiene_rol(self.id, "supplier")
 
     @property
     def token(self) -> str | None:

--- a/cacao_accounting/portal/__init__.py
+++ b/cacao_accounting/portal/__init__.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 - 2026 William José Moreno Reyes
+
+"""Módulo de Portal para Clientes y Proveedores (Cloud Mode únicamente)."""
+
+from functools import wraps
+from flask import Blueprint, abort, render_template, flash
+from flask_login import current_user, login_required
+from cacao_accounting.runtime_mode import is_desktop_mode
+from cacao_accounting.database import (
+    database,
+    SalesInvoice,
+    SalesOrder,
+    SalesQuotation,
+    DeliveryNote,
+    PurchaseInvoice,
+    PurchaseOrder,
+    PurchaseQuotation,
+    PurchaseReceipt,
+    SalesInvoiceItem,
+    SalesOrderItem,
+    SalesQuotationItem,
+    DeliveryNoteItem,
+    PurchaseInvoiceItem,
+    PurchaseOrderItem,
+    PurchaseQuotationItem,
+    PurchaseReceiptItem,
+)
+
+portal = Blueprint("portal", __name__, template_folder="templates")
+
+
+def requires_portal_role(role_name):
+    """Verifica que el usuario tenga el rol del portal correspondiente o sea administrador."""
+
+    def decorator(f):
+        @wraps(f)
+        @login_required
+        def decorated_function(*args, **kwargs):
+            if is_desktop_mode():
+                abort(403)
+            # Bypass para administradores
+            is_admin = False
+            if getattr(current_user, "classification", None) == "admin":
+                is_admin = True
+            else:
+                from cacao_accounting.auth.roles import tiene_rol
+
+                if tiene_rol(current_user.id, "admin"):
+                    is_admin = True
+
+            if is_admin:
+                return f(*args, **kwargs)
+
+            if role_name == "customer" and current_user.is_portal_customer:
+                if not current_user.party_id:
+                    flash("Usuario de portal sin cliente asignado.", "danger")
+                    abort(403)
+                return f(*args, **kwargs)
+
+            if role_name == "supplier" and current_user.is_portal_supplier:
+                if not current_user.party_id:
+                    flash("Usuario de portal sin proveedor asignado.", "danger")
+                    abort(403)
+                return f(*args, **kwargs)
+
+            abort(403)
+
+        return decorated_function
+
+    return decorator
+
+
+# ─── PORTAL DE CLIENTES ───────────────────────────────────────────────────────
+
+
+@portal.route("/customer")
+@requires_portal_role("customer")
+def customer_dashboard():
+    """Dashboard principal del portal de clientes."""
+    pid = current_user.party_id
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+
+    q_invoices = database.select(SalesInvoice).filter_by(document_type="sales_invoice")
+    q_orders = database.select(SalesOrder)
+    q_quotations = database.select(SalesQuotation)
+    q_deliveries = database.select(DeliveryNote)
+
+    if not is_admin and pid:
+        q_invoices = q_invoices.filter_by(customer_id=pid)
+        q_orders = q_orders.filter_by(customer_id=pid)
+        q_quotations = q_quotations.filter_by(customer_id=pid)
+        q_deliveries = q_deliveries.filter_by(customer_id=pid)
+
+    invoices = database.session.execute(q_invoices.order_by(SalesInvoice.posting_date.desc())).scalars().all()
+    orders = database.session.execute(q_orders.order_by(SalesOrder.posting_date.desc())).scalars().all()
+    quotations = database.session.execute(q_quotations.order_by(SalesQuotation.posting_date.desc())).scalars().all()
+    deliveries = database.session.execute(q_deliveries.order_by(DeliveryNote.posting_date.desc())).scalars().all()
+
+    return render_template(
+        "portal/customer_dashboard.html",
+        invoices=invoices,
+        orders=orders,
+        quotations=quotations,
+        deliveries=deliveries,
+        titulo="Portal de Clientes",
+    )
+
+
+@portal.route("/customer/invoice/<invoice_id>")
+@requires_portal_role("customer")
+def customer_invoice(invoice_id):
+    """Detalle de factura de venta para el cliente."""
+    invoice = database.session.get(SalesInvoice, invoice_id)
+    if not invoice:
+        abort(404)
+
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+    if not is_admin and invoice.customer_id != current_user.party_id:
+        abort(403)
+
+    items = database.session.execute(database.select(SalesInvoiceItem).filter_by(sales_invoice_id=invoice_id)).all()
+    return render_template("portal/invoice_detail.html", registro=invoice, items=items, role="customer")
+
+
+@portal.route("/customer/order/<order_id>")
+@requires_portal_role("customer")
+def customer_order(order_id):
+    """Detalle de orden de venta para el cliente."""
+    order = database.session.get(SalesOrder, order_id)
+    if not order:
+        abort(404)
+
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+    if not is_admin and order.customer_id != current_user.party_id:
+        abort(403)
+
+    items = database.session.execute(database.select(SalesOrderItem).filter_by(sales_order_id=order_id)).all()
+    return render_template("portal/order_detail.html", registro=order, items=items, role="customer")
+
+
+@portal.route("/customer/quotation/<quotation_id>")
+@requires_portal_role("customer")
+def customer_quotation(quotation_id):
+    """Detalle de cotización de venta para el cliente."""
+    quotation = database.session.get(SalesQuotation, quotation_id)
+    if not quotation:
+        abort(404)
+
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+    if not is_admin and quotation.customer_id != current_user.party_id:
+        abort(403)
+
+    items = database.session.execute(database.select(SalesQuotationItem).filter_by(sales_quotation_id=quotation_id)).all()
+    return render_template("portal/quotation_detail.html", registro=quotation, items=items, role="customer")
+
+
+@portal.route("/customer/delivery/<delivery_id>")
+@requires_portal_role("customer")
+def customer_delivery(delivery_id):
+    """Detalle de nota de entrega para el cliente."""
+    delivery = database.session.get(DeliveryNote, delivery_id)
+    if not delivery:
+        abort(404)
+
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+    if not is_admin and delivery.customer_id != current_user.party_id:
+        abort(403)
+
+    items = database.session.execute(database.select(DeliveryNoteItem).filter_by(delivery_note_id=delivery_id)).all()
+    return render_template("portal/delivery_detail.html", registro=delivery, items=items, role="customer")
+
+
+# ─── PORTAL DE PROVEEDORES ────────────────────────────────────────────────────
+
+
+@portal.route("/supplier")
+@requires_portal_role("supplier")
+def supplier_dashboard():
+    """Dashboard principal del portal de proveedores."""
+    pid = current_user.party_id
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+
+    q_invoices = database.select(PurchaseInvoice).filter_by(document_type="purchase_invoice")
+    q_orders = database.select(PurchaseOrder)
+    q_quotations = database.select(PurchaseQuotation)
+    q_receipts = database.select(PurchaseReceipt)
+
+    if not is_admin and pid:
+        q_invoices = q_invoices.filter_by(supplier_id=pid)
+        q_orders = q_orders.filter_by(supplier_id=pid)
+        q_quotations = q_quotations.filter_by(supplier_id=pid)
+        q_receipts = q_receipts.filter_by(supplier_id=pid)
+
+    invoices = database.session.execute(q_invoices.order_by(PurchaseInvoice.posting_date.desc())).scalars().all()
+    orders = database.session.execute(q_orders.order_by(PurchaseOrder.posting_date.desc())).scalars().all()
+    quotations = database.session.execute(q_quotations.order_by(PurchaseQuotation.posting_date.desc())).scalars().all()
+    receipts = database.session.execute(q_receipts.order_by(PurchaseReceipt.posting_date.desc())).scalars().all()
+
+    return render_template(
+        "portal/supplier_dashboard.html",
+        invoices=invoices,
+        orders=orders,
+        quotations=quotations,
+        receipts=receipts,
+        titulo="Portal de Proveedores",
+    )
+
+
+@portal.route("/supplier/invoice/<invoice_id>")
+@requires_portal_role("supplier")
+def supplier_invoice(invoice_id):
+    """Detalle de factura de compra para el proveedor."""
+    invoice = database.session.get(PurchaseInvoice, invoice_id)
+    if not invoice:
+        abort(404)
+
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+    if not is_admin and invoice.supplier_id != current_user.party_id:
+        abort(403)
+
+    items = database.session.execute(database.select(PurchaseInvoiceItem).filter_by(purchase_invoice_id=invoice_id)).all()
+    return render_template("portal/invoice_detail.html", registro=invoice, items=items, role="supplier")
+
+
+@portal.route("/supplier/order/<order_id>")
+@requires_portal_role("supplier")
+def supplier_order(order_id):
+    """Detalle de orden de compra para el proveedor."""
+    order = database.session.get(PurchaseOrder, order_id)
+    if not order:
+        abort(404)
+
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+    if not is_admin and order.supplier_id != current_user.party_id:
+        abort(403)
+
+    items = database.session.execute(database.select(PurchaseOrderItem).filter_by(purchase_order_id=order_id)).all()
+    return render_template("portal/order_detail.html", registro=order, items=items, role="supplier")
+
+
+@portal.route("/supplier/quotation/<quotation_id>")
+@requires_portal_role("supplier")
+def supplier_quotation(quotation_id):
+    """Detalle de solicitud de cotización para el proveedor."""
+    quotation = database.session.get(PurchaseQuotation, quotation_id)
+    if not quotation:
+        abort(404)
+
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+    if not is_admin and quotation.supplier_id != current_user.party_id:
+        abort(403)
+
+    items = database.session.execute(
+        database.select(PurchaseQuotationItem).filter_by(purchase_quotation_id=quotation_id)
+    ).all()
+    return render_template("portal/quotation_detail.html", registro=quotation, items=items, role="supplier")
+
+
+@portal.route("/supplier/receipt/<receipt_id>")
+@requires_portal_role("supplier")
+def supplier_receipt(receipt_id):
+    """Detalle de recepción de compra para el proveedor."""
+    receipt = database.session.get(PurchaseReceipt, receipt_id)
+    if not receipt:
+        abort(404)
+
+    is_admin = getattr(current_user, "classification", None) == "admin" or (
+        not current_user.is_portal_customer and not current_user.is_portal_supplier
+    )
+    if not is_admin and receipt.supplier_id != current_user.party_id:
+        abort(403)
+
+    items = database.session.execute(database.select(PurchaseReceiptItem).filter_by(purchase_receipt_id=receipt_id)).all()
+    return render_template("portal/receipt_detail.html", registro=receipt, items=items, role="supplier")

--- a/cacao_accounting/portal/__init__.py
+++ b/cacao_accounting/portal/__init__.py
@@ -3,7 +3,6 @@
 
 """Módulo de Portal para Clientes y Proveedores (Cloud Mode únicamente)."""
 
-from functools import wraps
 from flask import Blueprint, abort, render_template, flash
 from flask_login import current_user, login_required
 from cacao_accounting.runtime_mode import is_desktop_mode
@@ -39,44 +38,36 @@ def _is_user_admin() -> bool:
     return tiene_rol(current_user.id, "admin")
 
 
-def requires_portal_role(role_name):
+def check_portal_access(role_name: str) -> None:
     """Verifica que el usuario tenga el rol del portal correspondiente o sea administrador."""
+    if is_desktop_mode():
+        abort(403)
+    if _is_user_admin():
+        return
 
-    def decorator(f):
-        @wraps(f)
-        @login_required
-        def decorated_function(*args, **kwargs):
-            if is_desktop_mode():
-                abort(403)
-            if _is_user_admin():
-                return f(*args, **kwargs)
+    if role_name == "customer" and current_user.is_portal_customer:
+        if current_user.party_id:
+            return
+        flash("Usuario de portal sin cliente asignado.", "danger")
+        abort(403)
 
-            if role_name == "customer" and current_user.is_portal_customer:
-                if current_user.party_id:
-                    return f(*args, **kwargs)
-                flash("Usuario de portal sin cliente asignado.", "danger")
-                abort(403)
+    if role_name == "supplier" and current_user.is_portal_supplier:
+        if current_user.party_id:
+            return
+        flash("Usuario de portal sin proveedor asignado.", "danger")
+        abort(403)
 
-            if role_name == "supplier" and current_user.is_portal_supplier:
-                if current_user.party_id:
-                    return f(*args, **kwargs)
-                flash("Usuario de portal sin proveedor asignado.", "danger")
-                abort(403)
-
-            abort(403)
-
-        return decorated_function
-
-    return decorator
+    abort(403)
 
 
 # ─── PORTAL DE CLIENTES ───────────────────────────────────────────────────────
 
 
 @portal.route("/customer")
-@requires_portal_role("customer")
+@login_required
 def customer_dashboard():
     """Dashboard principal del portal de clientes."""
+    check_portal_access("customer")
     pid = current_user.party_id
     is_admin = getattr(current_user, "classification", None) == "admin" or (
         not current_user.is_portal_customer and not current_user.is_portal_supplier
@@ -109,9 +100,10 @@ def customer_dashboard():
 
 
 @portal.route("/customer/invoice/<invoice_id>")
-@requires_portal_role("customer")
+@login_required
 def customer_invoice(invoice_id):
     """Detalle de factura de venta para el cliente."""
+    check_portal_access("customer")
     invoice = database.session.get(SalesInvoice, invoice_id)
     if not invoice:
         abort(404)
@@ -127,9 +119,10 @@ def customer_invoice(invoice_id):
 
 
 @portal.route("/customer/order/<order_id>")
-@requires_portal_role("customer")
+@login_required
 def customer_order(order_id):
     """Detalle de orden de venta para el cliente."""
+    check_portal_access("customer")
     order = database.session.get(SalesOrder, order_id)
     if not order:
         abort(404)
@@ -145,9 +138,10 @@ def customer_order(order_id):
 
 
 @portal.route("/customer/quotation/<quotation_id>")
-@requires_portal_role("customer")
+@login_required
 def customer_quotation(quotation_id):
     """Detalle de cotización de venta para el cliente."""
+    check_portal_access("customer")
     quotation = database.session.get(SalesQuotation, quotation_id)
     if not quotation:
         abort(404)
@@ -163,9 +157,10 @@ def customer_quotation(quotation_id):
 
 
 @portal.route("/customer/delivery/<delivery_id>")
-@requires_portal_role("customer")
+@login_required
 def customer_delivery(delivery_id):
     """Detalle de nota de entrega para el cliente."""
+    check_portal_access("customer")
     delivery = database.session.get(DeliveryNote, delivery_id)
     if not delivery:
         abort(404)
@@ -184,9 +179,10 @@ def customer_delivery(delivery_id):
 
 
 @portal.route("/supplier")
-@requires_portal_role("supplier")
+@login_required
 def supplier_dashboard():
     """Dashboard principal del portal de proveedores."""
+    check_portal_access("supplier")
     pid = current_user.party_id
     is_admin = getattr(current_user, "classification", None) == "admin" or (
         not current_user.is_portal_customer and not current_user.is_portal_supplier
@@ -219,9 +215,10 @@ def supplier_dashboard():
 
 
 @portal.route("/supplier/invoice/<invoice_id>")
-@requires_portal_role("supplier")
+@login_required
 def supplier_invoice(invoice_id):
     """Detalle de factura de compra para el proveedor."""
+    check_portal_access("supplier")
     invoice = database.session.get(PurchaseInvoice, invoice_id)
     if not invoice:
         abort(404)
@@ -237,9 +234,10 @@ def supplier_invoice(invoice_id):
 
 
 @portal.route("/supplier/order/<order_id>")
-@requires_portal_role("supplier")
+@login_required
 def supplier_order(order_id):
     """Detalle de orden de compra para el proveedor."""
+    check_portal_access("supplier")
     order = database.session.get(PurchaseOrder, order_id)
     if not order:
         abort(404)
@@ -255,9 +253,10 @@ def supplier_order(order_id):
 
 
 @portal.route("/supplier/quotation/<quotation_id>")
-@requires_portal_role("supplier")
+@login_required
 def supplier_quotation(quotation_id):
     """Detalle de solicitud de cotización para el proveedor."""
+    check_portal_access("supplier")
     quotation = database.session.get(PurchaseQuotation, quotation_id)
     if not quotation:
         abort(404)
@@ -275,9 +274,10 @@ def supplier_quotation(quotation_id):
 
 
 @portal.route("/supplier/receipt/<receipt_id>")
-@requires_portal_role("supplier")
+@login_required
 def supplier_receipt(receipt_id):
     """Detalle de recepción de compra para el proveedor."""
+    check_portal_access("supplier")
     receipt = database.session.get(PurchaseReceipt, receipt_id)
     if not receipt:
         abort(404)

--- a/cacao_accounting/portal/__init__.py
+++ b/cacao_accounting/portal/__init__.py
@@ -30,6 +30,15 @@ from cacao_accounting.database import (
 portal = Blueprint("portal", __name__, template_folder="templates")
 
 
+def _is_user_admin() -> bool:
+    """Retorna verdadero si el usuario actual es administrador."""
+    if getattr(current_user, "classification", None) == "admin":
+        return True
+    from cacao_accounting.auth.roles import tiene_rol
+
+    return tiene_rol(current_user.id, "admin")
+
+
 def requires_portal_role(role_name):
     """Verifica que el usuario tenga el rol del portal correspondiente o sea administrador."""
 
@@ -39,30 +48,20 @@ def requires_portal_role(role_name):
         def decorated_function(*args, **kwargs):
             if is_desktop_mode():
                 abort(403)
-            # Bypass para administradores
-            is_admin = False
-            if getattr(current_user, "classification", None) == "admin":
-                is_admin = True
-            else:
-                from cacao_accounting.auth.roles import tiene_rol
-
-                if tiene_rol(current_user.id, "admin"):
-                    is_admin = True
-
-            if is_admin:
+            if _is_user_admin():
                 return f(*args, **kwargs)
 
             if role_name == "customer" and current_user.is_portal_customer:
-                if not current_user.party_id:
-                    flash("Usuario de portal sin cliente asignado.", "danger")
-                    abort(403)
-                return f(*args, **kwargs)
+                if current_user.party_id:
+                    return f(*args, **kwargs)
+                flash("Usuario de portal sin cliente asignado.", "danger")
+                abort(403)
 
             if role_name == "supplier" and current_user.is_portal_supplier:
-                if not current_user.party_id:
-                    flash("Usuario de portal sin proveedor asignado.", "danger")
-                    abort(403)
-                return f(*args, **kwargs)
+                if current_user.party_id:
+                    return f(*args, **kwargs)
+                flash("Usuario de portal sin proveedor asignado.", "danger")
+                abort(403)
 
             abort(403)
 

--- a/cacao_accounting/portal/templates/portal/base_portal.html
+++ b/cacao_accounting/portal/templates/portal/base_portal.html
@@ -7,30 +7,11 @@
 <head>
   {{ macros.headertags() }}
   <title>{{ title }}</title>
-  <style>
-    /* Full-width content override because there is no sidebar */
-    .ca-content {
-      margin-left: 0 !important;
-      padding-top: 5rem !important;
-      padding-left: 1.5rem !important;
-      padding-right: 1.5rem !important;
-      width: 100% !important;
-      max-width: 1200px !important;
-      margin-left: auto !important;
-      margin-right: auto !important;
-    }
-    .portal-section-header {
-      margin-top: 2rem;
-      margin-bottom: 1rem;
-      border-bottom: 2px solid var(--ca-border);
-      padding-bottom: 0.5rem;
-    }
-  </style>
 </head>
 
 <body>
   {{ macros.cabecera() }}
-  <main class="ca-content">
+  <main class="ca-content ca-content-full">
     {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
     <div class="container-fluid px-0 pt-0 pb-3">

--- a/cacao_accounting/portal/templates/portal/base_portal.html
+++ b/cacao_accounting/portal/templates/portal/base_portal.html
@@ -1,0 +1,59 @@
+{% import "macros.html" as macros %}
+{% set title = titulo|default("Portal de Servicios - Cacao Accounting") %}
+
+<!doctype html>
+<html lang="es">
+
+<head>
+  {{ macros.headertags() }}
+  <title>{{ title }}</title>
+  <style>
+    /* Full-width content override because there is no sidebar */
+    .ca-content {
+      margin-left: 0 !important;
+      padding-top: 5rem !important;
+      padding-left: 1.5rem !important;
+      padding-right: 1.5rem !important;
+      width: 100% !important;
+      max-width: 1200px !important;
+      margin-left: auto !important;
+      margin-right: auto !important;
+    }
+    .portal-section-header {
+      margin-top: 2rem;
+      margin-bottom: 1rem;
+      border-bottom: 2px solid var(--ca-border);
+      padding-bottom: 0.5rem;
+    }
+  </style>
+</head>
+
+<body>
+  {{ macros.cabecera() }}
+  <main class="ca-content">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class="container-fluid px-0 pt-0 pb-3">
+      <div class="d-grid gap-2">
+        {% for category, message in messages %}
+        {% set alert_class = 'alert-info' %}
+        {% if category == 'success' %}
+        {% set alert_class = 'alert-success' %}
+        {% elif category == 'warning' %}
+        {% set alert_class = 'alert-warning' %}
+        {% elif category == 'danger' %}
+        {% set alert_class = 'alert-danger' %}
+        {% endif %}
+        <div class="alert {{ alert_class }} mb-0" role="alert">{{ message }}</div>
+        {% endfor %}
+      </div>
+    </div>
+    {% endif %}
+    {% endwith %}
+
+    {% block contenido %}
+    {% endblock %}
+  </main>
+</body>
+
+</html>

--- a/cacao_accounting/portal/templates/portal/customer_dashboard.html
+++ b/cacao_accounting/portal/templates/portal/customer_dashboard.html
@@ -1,0 +1,164 @@
+{% extends "portal/base_portal.html" %}
+
+{% block contenido %}
+<div class="row mb-4">
+  <div class="col-12">
+    <div class="p-4 bg-light border rounded-3 shadow-sm">
+      <h2><i class="bi bi-house-door-fill text-primary"></i> {{ _('Portal del Cliente') }}</h2>
+      <p class="lead mb-0">{{ _('Bienvenido a su portal de servicios de lectura. Aquí puede consultar sus cotizaciones, pedidos, remisiones y facturas.') }}</p>
+    </div>
+  </div>
+</div>
+
+<!-- Cotizaciones de Venta -->
+<div class="portal-section-header d-flex justify-content-between align-items-center">
+  <h4><i class="bi bi-file-earmark-text text-secondary me-2"></i>{{ _('Cotizaciones de Venta') }}</h4>
+  <span class="badge bg-secondary">{{ quotations|length }}</span>
+</div>
+<div class="table-responsive bg-white border rounded shadow-sm mb-4">
+  <table class="table table-hover align-middle mb-0">
+    <thead class="table-light">
+      <tr>
+        <th scope="col">{{ _('Número') }}</th>
+        <th scope="col">{{ _('Fecha') }}</th>
+        <th scope="col" class="text-end">{{ _('Total') }}</th>
+        <th scope="col">{{ _('Estado') }}</th>
+        <th scope="col" class="text-center" style="width: 10%;">{{ _('Acción') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in quotations %}
+      <tr>
+        <td><strong>{{ item.document_no or item.id }}</strong></td>
+        <td>{{ item.posting_date }}</td>
+        <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
+        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td class="text-center">
+          <a href="{{ url_for('portal.customer_quotation', quotation_id=item.id) }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-eye"></i> {{ _('Ver') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="5" class="text-center text-muted py-3">{{ _('No se encontraron cotizaciones.') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Órdenes de Venta -->
+<div class="portal-section-header d-flex justify-content-between align-items-center">
+  <h4><i class="bi bi-cart-fill text-success me-2"></i>{{ _('Órdenes de Venta') }}</h4>
+  <span class="badge bg-secondary">{{ orders|length }}</span>
+</div>
+<div class="table-responsive bg-white border rounded shadow-sm mb-4">
+  <table class="table table-hover align-middle mb-0">
+    <thead class="table-light">
+      <tr>
+        <th scope="col">{{ _('Número') }}</th>
+        <th scope="col">{{ _('Fecha') }}</th>
+        <th scope="col" class="text-end">{{ _('Total') }}</th>
+        <th scope="col">{{ _('Estado') }}</th>
+        <th scope="col" class="text-center" style="width: 10%;">{{ _('Acción') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in orders %}
+      <tr>
+        <td><strong>{{ item.document_no or item.id }}</strong></td>
+        <td>{{ item.posting_date }}</td>
+        <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
+        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td class="text-center">
+          <a href="{{ url_for('portal.customer_order', order_id=item.id) }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-eye"></i> {{ _('Ver') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="5" class="text-center text-muted py-3">{{ _('No se encontraron órdenes de venta.') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Notas de Entrega / Remisiones -->
+<div class="portal-section-header d-flex justify-content-between align-items-center">
+  <h4><i class="bi bi-truck text-warning me-2"></i>{{ _('Notas de Entrega / Remisiones') }}</h4>
+  <span class="badge bg-secondary">{{ deliveries|length }}</span>
+</div>
+<div class="table-responsive bg-white border rounded shadow-sm mb-4">
+  <table class="table table-hover align-middle mb-0">
+    <thead class="table-light">
+      <tr>
+        <th scope="col">{{ _('Número') }}</th>
+        <th scope="col">{{ _('Fecha') }}</th>
+        <th scope="col" class="text-end">{{ _('Total') }}</th>
+        <th scope="col">{{ _('Estado') }}</th>
+        <th scope="col" class="text-center" style="width: 10%;">{{ _('Acción') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in deliveries %}
+      <tr>
+        <td><strong>{{ item.document_no or item.id }}</strong></td>
+        <td>{{ item.posting_date }}</td>
+        <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
+        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td class="text-center">
+          <a href="{{ url_for('portal.customer_delivery', delivery_id=item.id) }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-eye"></i> {{ _('Ver') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="5" class="text-center text-muted py-3">{{ _('No se encontraron notas de entrega.') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Facturas de Venta -->
+<div class="portal-section-header d-flex justify-content-between align-items-center">
+  <h4><i class="bi bi-receipt text-danger me-2"></i>{{ _('Facturas de Venta') }}</h4>
+  <span class="badge bg-secondary">{{ invoices|length }}</span>
+</div>
+<div class="table-responsive bg-white border rounded shadow-sm mb-4">
+  <table class="table table-hover align-middle mb-0">
+    <thead class="table-light">
+      <tr>
+        <th scope="col">{{ _('Número') }}</th>
+        <th scope="col">{{ _('Fecha') }}</th>
+        <th scope="col" class="text-end">{{ _('Total') }}</th>
+        <th scope="col">{{ _('Estado') }}</th>
+        <th scope="col" class="text-center" style="width: 10%;">{{ _('Acción') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in invoices %}
+      <tr>
+        <td><strong>{{ item.document_no or item.id }}</strong></td>
+        <td>{{ item.posting_date }}</td>
+        <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
+        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td class="text-center">
+          <a href="{{ url_for('portal.customer_invoice', invoice_id=item.id) }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-eye"></i> {{ _('Ver') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="5" class="text-center text-muted py-3">{{ _('No se encontraron facturas.') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/cacao_accounting/portal/templates/portal/customer_dashboard.html
+++ b/cacao_accounting/portal/templates/portal/customer_dashboard.html
@@ -12,7 +12,7 @@
 
 <!-- Cotizaciones de Venta -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-file-earmark-text text-secondary me-2"></i>{{ _('Cotizaciones de Venta') }}</h4>
+  <h4><i class="bi bi-file-earmark-text text-secondary me-2" aria-hidden="true"></i>{{ _('Cotizaciones de Venta') }}</h4>
   <span class="badge bg-secondary">{{ quotations|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -50,7 +50,7 @@
 
 <!-- Órdenes de Venta -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-cart-fill text-success me-2"></i>{{ _('Órdenes de Venta') }}</h4>
+  <h4><i class="bi bi-cart-fill text-success me-2" aria-hidden="true"></i>{{ _('Órdenes de Venta') }}</h4>
   <span class="badge bg-secondary">{{ orders|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -88,7 +88,7 @@
 
 <!-- Notas de Entrega / Remisiones -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-truck text-warning me-2"></i>{{ _('Notas de Entrega / Remisiones') }}</h4>
+  <h4><i class="bi bi-truck text-warning me-2" aria-hidden="true"></i>{{ _('Notas de Entrega / Remisiones') }}</h4>
   <span class="badge bg-secondary">{{ deliveries|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -126,7 +126,7 @@
 
 <!-- Facturas de Venta -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-receipt text-danger me-2"></i>{{ _('Facturas de Venta') }}</h4>
+  <h4><i class="bi bi-receipt text-danger me-2" aria-hidden="true"></i>{{ _('Facturas de Venta') }}</h4>
   <span class="badge bg-secondary">{{ invoices|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">

--- a/cacao_accounting/portal/templates/portal/customer_dashboard.html
+++ b/cacao_accounting/portal/templates/portal/customer_dashboard.html
@@ -4,7 +4,7 @@
 <div class="row mb-4">
   <div class="col-12">
     <div class="p-4 bg-light border rounded-3 shadow-sm">
-      <h2><i class="bi bi-house-door-fill text-primary"></i> {{ _('Portal del Cliente') }}</h2>
+      <h2><span class="bi bi-house-door-fill text-primary"></span> {{ _('Portal del Cliente') }}</h2>
       <p class="lead mb-0">{{ _('Bienvenido a su portal de servicios de lectura. Aquí puede consultar sus cotizaciones, pedidos, remisiones y facturas.') }}</p>
     </div>
   </div>
@@ -12,7 +12,7 @@
 
 <!-- Cotizaciones de Venta -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-file-earmark-text text-secondary me-2" aria-hidden="true"></i>{{ _('Cotizaciones de Venta') }}</h4>
+  <h4><span class="bi bi-file-earmark-text text-secondary me-2" aria-hidden="true"></span>{{ _('Cotizaciones de Venta') }}</h4>
   <span class="badge bg-secondary">{{ quotations|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -35,7 +35,7 @@
         <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.customer_quotation', quotation_id=item.id) }}" class="btn btn-sm btn-outline-primary">
-            <i class="bi bi-eye"></i> {{ _('Ver') }}
+            <span class="bi bi-eye"></span> {{ _('Ver') }}
           </a>
         </td>
       </tr>
@@ -50,7 +50,7 @@
 
 <!-- Órdenes de Venta -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-cart-fill text-success me-2" aria-hidden="true"></i>{{ _('Órdenes de Venta') }}</h4>
+  <h4><span class="bi bi-cart-fill text-success me-2" aria-hidden="true"></span>{{ _('Órdenes de Venta') }}</h4>
   <span class="badge bg-secondary">{{ orders|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -73,7 +73,7 @@
         <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.customer_order', order_id=item.id) }}" class="btn btn-sm btn-outline-primary">
-            <i class="bi bi-eye"></i> {{ _('Ver') }}
+            <span class="bi bi-eye"></span> {{ _('Ver') }}
           </a>
         </td>
       </tr>
@@ -88,7 +88,7 @@
 
 <!-- Notas de Entrega / Remisiones -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-truck text-warning me-2" aria-hidden="true"></i>{{ _('Notas de Entrega / Remisiones') }}</h4>
+  <h4><span class="bi bi-truck text-warning me-2" aria-hidden="true"></span>{{ _('Notas de Entrega / Remisiones') }}</h4>
   <span class="badge bg-secondary">{{ deliveries|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -111,7 +111,7 @@
         <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.customer_delivery', delivery_id=item.id) }}" class="btn btn-sm btn-outline-primary">
-            <i class="bi bi-eye"></i> {{ _('Ver') }}
+            <span class="bi bi-eye"></span> {{ _('Ver') }}
           </a>
         </td>
       </tr>
@@ -126,7 +126,7 @@
 
 <!-- Facturas de Venta -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-receipt text-danger me-2" aria-hidden="true"></i>{{ _('Facturas de Venta') }}</h4>
+  <h4><span class="bi bi-receipt text-danger me-2" aria-hidden="true"></span>{{ _('Facturas de Venta') }}</h4>
   <span class="badge bg-secondary">{{ invoices|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -149,7 +149,7 @@
         <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.customer_invoice', invoice_id=item.id) }}" class="btn btn-sm btn-outline-primary">
-            <i class="bi bi-eye"></i> {{ _('Ver') }}
+            <span class="bi bi-eye"></span> {{ _('Ver') }}
           </a>
         </td>
       </tr>

--- a/cacao_accounting/portal/templates/portal/delivery_detail.html
+++ b/cacao_accounting/portal/templates/portal/delivery_detail.html
@@ -7,9 +7,9 @@
   <ol class="breadcrumb lh-sm">
     <li class="breadcrumb-item">
       {% if role == 'customer' %}
-      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Clientes') }}</a>
       {% else %}
-      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Proveedores') }}</a>
       {% endif %}
     </li>
     <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>

--- a/cacao_accounting/portal/templates/portal/delivery_detail.html
+++ b/cacao_accounting/portal/templates/portal/delivery_detail.html
@@ -1,0 +1,36 @@
+{% extends "portal/base_portal.html" %}
+{% block contenido %}
+{% import "macros.html" as macros %}
+{% import "detail_view_macros.html" as dv_macros %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb lh-sm">
+    <li class="breadcrumb-item">
+      {% if role == 'customer' %}
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      {% else %}
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      {% endif %}
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>
+  </ol>
+</nav>
+
+{% set currency_code = document_currency_code(registro) %}
+{{ dv_macros.detail_header(
+    registro.document_no or registro.id,
+    _('Nota de Entrega / Remisión'),
+    registro.docstatus,
+    "",
+    [
+      (_('Número'), registro.document_no),
+      (_('Cliente'), registro.customer_name),
+      (_('Fecha'), registro.posting_date),
+      (_('Total'), format_money_with_currency(registro.grand_total, currency_code)),
+      (_('Moneda'), currency_code),
+      (_('Observaciones'), registro.remarks)
+    ],
+    'bi-truck'
+) }}
+{{ macros.lineas_tabla_lectura(items, currency_code) }}
+{% endblock %}

--- a/cacao_accounting/portal/templates/portal/invoice_detail.html
+++ b/cacao_accounting/portal/templates/portal/invoice_detail.html
@@ -1,0 +1,36 @@
+{% extends "portal/base_portal.html" %}
+{% block contenido %}
+{% import "macros.html" as macros %}
+{% import "detail_view_macros.html" as dv_macros %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb lh-sm">
+    <li class="breadcrumb-item">
+      {% if role == 'customer' %}
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      {% else %}
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      {% endif %}
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>
+  </ol>
+</nav>
+
+{% set currency_code = document_currency_code(registro) %}
+{{ dv_macros.detail_header(
+    registro.document_no or registro.id,
+    _('Factura de Venta') if role == 'customer' else _('Factura de Compra'),
+    registro.docstatus,
+    "",
+    [
+      (_('Número'), registro.document_no),
+      (_('Cliente') if role == 'customer' else _('Proveedor'), registro.customer_name if role == 'customer' else registro.supplier_name),
+      (_('Fecha'), registro.posting_date),
+      (_('Total'), format_money_with_currency(registro.grand_total, currency_code)),
+      (_('Moneda'), currency_code),
+      (_('Observaciones'), registro.remarks)
+    ],
+    'bi-receipt'
+) }}
+{{ macros.lineas_tabla_lectura(items, currency_code) }}
+{% endblock %}

--- a/cacao_accounting/portal/templates/portal/invoice_detail.html
+++ b/cacao_accounting/portal/templates/portal/invoice_detail.html
@@ -7,9 +7,9 @@
   <ol class="breadcrumb lh-sm">
     <li class="breadcrumb-item">
       {% if role == 'customer' %}
-      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Clientes') }}</a>
       {% else %}
-      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Proveedores') }}</a>
       {% endif %}
     </li>
     <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>

--- a/cacao_accounting/portal/templates/portal/order_detail.html
+++ b/cacao_accounting/portal/templates/portal/order_detail.html
@@ -1,0 +1,36 @@
+{% extends "portal/base_portal.html" %}
+{% block contenido %}
+{% import "macros.html" as macros %}
+{% import "detail_view_macros.html" as dv_macros %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb lh-sm">
+    <li class="breadcrumb-item">
+      {% if role == 'customer' %}
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      {% else %}
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      {% endif %}
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>
+  </ol>
+</nav>
+
+{% set currency_code = document_currency_code(registro) %}
+{{ dv_macros.detail_header(
+    registro.document_no or registro.id,
+    _('Orden de Venta') if role == 'customer' else _('Orden de Compra'),
+    registro.docstatus,
+    "",
+    [
+      (_('Número'), registro.document_no),
+      (_('Cliente') if role == 'customer' else _('Proveedor'), registro.customer_name if role == 'customer' else registro.supplier_name),
+      (_('Fecha'), registro.posting_date),
+      (_('Total'), format_money_with_currency(registro.grand_total, currency_code)),
+      (_('Moneda'), currency_code),
+      (_('Observaciones'), registro.remarks)
+    ],
+    'bi-cart4'
+) }}
+{{ macros.lineas_tabla_lectura(items, currency_code) }}
+{% endblock %}

--- a/cacao_accounting/portal/templates/portal/order_detail.html
+++ b/cacao_accounting/portal/templates/portal/order_detail.html
@@ -7,9 +7,9 @@
   <ol class="breadcrumb lh-sm">
     <li class="breadcrumb-item">
       {% if role == 'customer' %}
-      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Clientes') }}</a>
       {% else %}
-      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Proveedores') }}</a>
       {% endif %}
     </li>
     <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>

--- a/cacao_accounting/portal/templates/portal/quotation_detail.html
+++ b/cacao_accounting/portal/templates/portal/quotation_detail.html
@@ -7,9 +7,9 @@
   <ol class="breadcrumb lh-sm">
     <li class="breadcrumb-item">
       {% if role == 'customer' %}
-      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Clientes') }}</a>
       {% else %}
-      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Proveedores') }}</a>
       {% endif %}
     </li>
     <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>

--- a/cacao_accounting/portal/templates/portal/quotation_detail.html
+++ b/cacao_accounting/portal/templates/portal/quotation_detail.html
@@ -1,0 +1,36 @@
+{% extends "portal/base_portal.html" %}
+{% block contenido %}
+{% import "macros.html" as macros %}
+{% import "detail_view_macros.html" as dv_macros %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb lh-sm">
+    <li class="breadcrumb-item">
+      {% if role == 'customer' %}
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      {% else %}
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      {% endif %}
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>
+  </ol>
+</nav>
+
+{% set currency_code = document_currency_code(registro) %}
+{{ dv_macros.detail_header(
+    registro.document_no or registro.id,
+    _('Cotización de Venta') if role == 'customer' else _('Solicitud de Cotización de Compra'),
+    registro.docstatus,
+    "",
+    [
+      (_('Número'), registro.document_no),
+      (_('Cliente') if role == 'customer' else _('Proveedor'), registro.customer_name if role == 'customer' else registro.supplier_name),
+      (_('Fecha'), registro.posting_date),
+      (_('Total'), format_money_with_currency(registro.grand_total, currency_code)),
+      (_('Moneda'), currency_code),
+      (_('Observaciones'), registro.remarks)
+    ],
+    'bi-file-earmark-text'
+) }}
+{{ macros.lineas_tabla_lectura(items, currency_code) }}
+{% endblock %}

--- a/cacao_accounting/portal/templates/portal/receipt_detail.html
+++ b/cacao_accounting/portal/templates/portal/receipt_detail.html
@@ -1,0 +1,36 @@
+{% extends "portal/base_portal.html" %}
+{% block contenido %}
+{% import "macros.html" as macros %}
+{% import "detail_view_macros.html" as dv_macros %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb lh-sm">
+    <li class="breadcrumb-item">
+      {% if role == 'customer' %}
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      {% else %}
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      {% endif %}
+    </li>
+    <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>
+  </ol>
+</nav>
+
+{% set currency_code = document_currency_code(registro) %}
+{{ dv_macros.detail_header(
+    registro.document_no or registro.id,
+    _('Recepción de Compra'),
+    registro.docstatus,
+    "",
+    [
+      (_('Número'), registro.document_no),
+      (_('Proveedor'), registro.supplier_name),
+      (_('Fecha'), registro.posting_date),
+      (_('Total'), format_money_with_currency(registro.grand_total, currency_code)),
+      (_('Moneda'), currency_code),
+      (_('Observaciones'), registro.remarks)
+    ],
+    'bi-truck'
+) }}
+{{ macros.lineas_tabla_lectura(items, currency_code) }}
+{% endblock %}

--- a/cacao_accounting/portal/templates/portal/receipt_detail.html
+++ b/cacao_accounting/portal/templates/portal/receipt_detail.html
@@ -7,9 +7,9 @@
   <ol class="breadcrumb lh-sm">
     <li class="breadcrumb-item">
       {% if role == 'customer' %}
-      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Clientes') }}</a>
+      <a href="{{ url_for('portal.customer_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Clientes') }}</a>
       {% else %}
-      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><i class="bi bi-house"></i> {{ _('Portal de Proveedores') }}</a>
+      <a href="{{ url_for('portal.supplier_dashboard') }}" class="link-dark"><span class="bi bi-house"></span> {{ _('Portal de Proveedores') }}</a>
       {% endif %}
     </li>
     <li class="breadcrumb-item active" aria-current="page">{{ registro.document_no or registro.id }}</li>

--- a/cacao_accounting/portal/templates/portal/supplier_dashboard.html
+++ b/cacao_accounting/portal/templates/portal/supplier_dashboard.html
@@ -4,7 +4,7 @@
 <div class="row mb-4">
   <div class="col-12">
     <div class="p-4 bg-light border rounded-3 shadow-sm">
-      <h2><i class="bi bi-house-door-fill text-primary"></i> {{ _('Portal del Proveedor') }}</h2>
+      <h2><span class="bi bi-house-door-fill text-primary"></span> {{ _('Portal del Proveedor') }}</h2>
       <p class="lead mb-0">{{ _('Bienvenido a su portal de servicios de lectura. Aquí puede consultar sus solicitudes de cotización, órdenes de compra, recepciones de almacén y facturas de compra.') }}</p>
     </div>
   </div>
@@ -12,7 +12,7 @@
 
 <!-- Solicitudes de Cotización -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-file-earmark-text text-secondary me-2" aria-hidden="true"></i>{{ _('Solicitudes de Cotización de Compra') }}</h4>
+  <h4><span class="bi bi-file-earmark-text text-secondary me-2" aria-hidden="true"></span>{{ _('Solicitudes de Cotización de Compra') }}</h4>
   <span class="badge bg-secondary">{{ quotations|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -35,7 +35,7 @@
         <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.supplier_quotation', quotation_id=item.id) }}" class="btn btn-sm btn-outline-primary">
-            <i class="bi bi-eye"></i> {{ _('Ver') }}
+            <span class="bi bi-eye"></span> {{ _('Ver') }}
           </a>
         </td>
       </tr>
@@ -50,7 +50,7 @@
 
 <!-- Órdenes de Compra -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-cart-fill text-success me-2" aria-hidden="true"></i>{{ _('Órdenes de Compra') }}</h4>
+  <h4><span class="bi bi-cart-fill text-success me-2" aria-hidden="true"></span>{{ _('Órdenes de Compra') }}</h4>
   <span class="badge bg-secondary">{{ orders|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -73,7 +73,7 @@
         <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.supplier_order', order_id=item.id) }}" class="btn btn-sm btn-outline-primary">
-            <i class="bi bi-eye"></i> {{ _('Ver') }}
+            <span class="bi bi-eye"></span> {{ _('Ver') }}
           </a>
         </td>
       </tr>
@@ -88,7 +88,7 @@
 
 <!-- Recepciones de Compra -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-truck text-warning me-2" aria-hidden="true"></i>{{ _('Recepciones de Compra') }}</h4>
+  <h4><span class="bi bi-truck text-warning me-2" aria-hidden="true"></span>{{ _('Recepciones de Compra') }}</h4>
   <span class="badge bg-secondary">{{ receipts|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -111,7 +111,7 @@
         <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.supplier_receipt', receipt_id=item.id) }}" class="btn btn-sm btn-outline-primary">
-            <i class="bi bi-eye"></i> {{ _('Ver') }}
+            <span class="bi bi-eye"></span> {{ _('Ver') }}
           </a>
         </td>
       </tr>
@@ -126,7 +126,7 @@
 
 <!-- Facturas de Compra -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-receipt text-danger me-2" aria-hidden="true"></i>{{ _('Facturas de Compra') }}</h4>
+  <h4><span class="bi bi-receipt text-danger me-2" aria-hidden="true"></span>{{ _('Facturas de Compra') }}</h4>
   <span class="badge bg-secondary">{{ invoices|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -149,7 +149,7 @@
         <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.supplier_invoice', invoice_id=item.id) }}" class="btn btn-sm btn-outline-primary">
-            <i class="bi bi-eye"></i> {{ _('Ver') }}
+            <span class="bi bi-eye"></span> {{ _('Ver') }}
           </a>
         </td>
       </tr>

--- a/cacao_accounting/portal/templates/portal/supplier_dashboard.html
+++ b/cacao_accounting/portal/templates/portal/supplier_dashboard.html
@@ -1,0 +1,164 @@
+{% extends "portal/base_portal.html" %}
+
+{% block contenido %}
+<div class="row mb-4">
+  <div class="col-12">
+    <div class="p-4 bg-light border rounded-3 shadow-sm">
+      <h2><i class="bi bi-house-door-fill text-primary"></i> {{ _('Portal del Proveedor') }}</h2>
+      <p class="lead mb-0">{{ _('Bienvenido a su portal de servicios de lectura. Aquí puede consultar sus solicitudes de cotización, órdenes de compra, recepciones de almacén y facturas de compra.') }}</p>
+    </div>
+  </div>
+</div>
+
+<!-- Solicitudes de Cotización -->
+<div class="portal-section-header d-flex justify-content-between align-items-center">
+  <h4><i class="bi bi-file-earmark-text text-secondary me-2"></i>{{ _('Solicitudes de Cotización de Compra') }}</h4>
+  <span class="badge bg-secondary">{{ quotations|length }}</span>
+</div>
+<div class="table-responsive bg-white border rounded shadow-sm mb-4">
+  <table class="table table-hover align-middle mb-0">
+    <thead class="table-light">
+      <tr>
+        <th scope="col">{{ _('Número') }}</th>
+        <th scope="col">{{ _('Fecha') }}</th>
+        <th scope="col" class="text-end">{{ _('Total') }}</th>
+        <th scope="col">{{ _('Estado') }}</th>
+        <th scope="col" class="text-center" style="width: 10%;">{{ _('Acción') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in quotations %}
+      <tr>
+        <td><strong>{{ item.document_no or item.id }}</strong></td>
+        <td>{{ item.posting_date }}</td>
+        <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
+        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td class="text-center">
+          <a href="{{ url_for('portal.supplier_quotation', quotation_id=item.id) }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-eye"></i> {{ _('Ver') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="5" class="text-center text-muted py-3">{{ _('No se encontraron solicitudes de cotización.') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Órdenes de Compra -->
+<div class="portal-section-header d-flex justify-content-between align-items-center">
+  <h4><i class="bi bi-cart-fill text-success me-2"></i>{{ _('Órdenes de Compra') }}</h4>
+  <span class="badge bg-secondary">{{ orders|length }}</span>
+</div>
+<div class="table-responsive bg-white border rounded shadow-sm mb-4">
+  <table class="table table-hover align-middle mb-0">
+    <thead class="table-light">
+      <tr>
+        <th scope="col">{{ _('Número') }}</th>
+        <th scope="col">{{ _('Fecha') }}</th>
+        <th scope="col" class="text-end">{{ _('Total') }}</th>
+        <th scope="col">{{ _('Estado') }}</th>
+        <th scope="col" class="text-center" style="width: 10%;">{{ _('Acción') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in orders %}
+      <tr>
+        <td><strong>{{ item.document_no or item.id }}</strong></td>
+        <td>{{ item.posting_date }}</td>
+        <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
+        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td class="text-center">
+          <a href="{{ url_for('portal.supplier_order', order_id=item.id) }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-eye"></i> {{ _('Ver') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="5" class="text-center text-muted py-3">{{ _('No se encontraron órdenes de compra.') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Recepciones de Compra -->
+<div class="portal-section-header d-flex justify-content-between align-items-center">
+  <h4><i class="bi bi-truck text-warning me-2"></i>{{ _('Recepciones de Compra') }}</h4>
+  <span class="badge bg-secondary">{{ receipts|length }}</span>
+</div>
+<div class="table-responsive bg-white border rounded shadow-sm mb-4">
+  <table class="table table-hover align-middle mb-0">
+    <thead class="table-light">
+      <tr>
+        <th scope="col">{{ _('Número') }}</th>
+        <th scope="col">{{ _('Fecha') }}</th>
+        <th scope="col" class="text-end">{{ _('Total') }}</th>
+        <th scope="col">{{ _('Estado') }}</th>
+        <th scope="col" class="text-center" style="width: 10%;">{{ _('Acción') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in receipts %}
+      <tr>
+        <td><strong>{{ item.document_no or item.id }}</strong></td>
+        <td>{{ item.posting_date }}</td>
+        <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
+        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td class="text-center">
+          <a href="{{ url_for('portal.supplier_receipt', receipt_id=item.id) }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-eye"></i> {{ _('Ver') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="5" class="text-center text-muted py-3">{{ _('No se encontraron recepciones.') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Facturas de Compra -->
+<div class="portal-section-header d-flex justify-content-between align-items-center">
+  <h4><i class="bi bi-receipt text-danger me-2"></i>{{ _('Facturas de Compra') }}</h4>
+  <span class="badge bg-secondary">{{ invoices|length }}</span>
+</div>
+<div class="table-responsive bg-white border rounded shadow-sm mb-4">
+  <table class="table table-hover align-middle mb-0">
+    <thead class="table-light">
+      <tr>
+        <th scope="col">{{ _('Número') }}</th>
+        <th scope="col">{{ _('Fecha') }}</th>
+        <th scope="col" class="text-end">{{ _('Total') }}</th>
+        <th scope="col">{{ _('Estado') }}</th>
+        <th scope="col" class="text-center" style="width: 10%;">{{ _('Acción') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in invoices %}
+      <tr>
+        <td><strong>{{ item.document_no or item.id }}</strong></td>
+        <td>{{ item.posting_date }}</td>
+        <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
+        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td class="text-center">
+          <a href="{{ url_for('portal.supplier_invoice', invoice_id=item.id) }}" class="btn btn-sm btn-outline-primary">
+            <i class="bi bi-eye"></i> {{ _('Ver') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="5" class="text-center text-muted py-3">{{ _('No se encontraron facturas.') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/cacao_accounting/portal/templates/portal/supplier_dashboard.html
+++ b/cacao_accounting/portal/templates/portal/supplier_dashboard.html
@@ -12,7 +12,7 @@
 
 <!-- Solicitudes de Cotización -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-file-earmark-text text-secondary me-2"></i>{{ _('Solicitudes de Cotización de Compra') }}</h4>
+  <h4><i class="bi bi-file-earmark-text text-secondary me-2" aria-hidden="true"></i>{{ _('Solicitudes de Cotización de Compra') }}</h4>
   <span class="badge bg-secondary">{{ quotations|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -50,7 +50,7 @@
 
 <!-- Órdenes de Compra -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-cart-fill text-success me-2"></i>{{ _('Órdenes de Compra') }}</h4>
+  <h4><i class="bi bi-cart-fill text-success me-2" aria-hidden="true"></i>{{ _('Órdenes de Compra') }}</h4>
   <span class="badge bg-secondary">{{ orders|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -88,7 +88,7 @@
 
 <!-- Recepciones de Compra -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-truck text-warning me-2"></i>{{ _('Recepciones de Compra') }}</h4>
+  <h4><i class="bi bi-truck text-warning me-2" aria-hidden="true"></i>{{ _('Recepciones de Compra') }}</h4>
   <span class="badge bg-secondary">{{ receipts|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">
@@ -126,7 +126,7 @@
 
 <!-- Facturas de Compra -->
 <div class="portal-section-header d-flex justify-content-between align-items-center">
-  <h4><i class="bi bi-receipt text-danger me-2"></i>{{ _('Facturas de Compra') }}</h4>
+  <h4><i class="bi bi-receipt text-danger me-2" aria-hidden="true"></i>{{ _('Facturas de Compra') }}</h4>
   <span class="badge bg-secondary">{{ invoices|length }}</span>
 </div>
 <div class="table-responsive bg-white border rounded shadow-sm mb-4">

--- a/cacao_accounting/static/css/cacaoaccounting.css
+++ b/cacao_accounting/static/css/cacaoaccounting.css
@@ -1456,3 +1456,21 @@ nav[aria-label="breadcrumb"] {
   border-radius: var(--ca-radius) !important;
   box-shadow: var(--ca-shadow-sm);
 }
+
+.ca-content-full {
+  margin-left: 0 !important;
+  padding-top: 5rem !important;
+  padding-left: 1.5rem !important;
+  padding-right: 1.5rem !important;
+  width: 100% !important;
+  max-width: 1200px !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+
+.portal-section-header {
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  border-bottom: 2px solid var(--ca-border);
+  padding-bottom: 0.5rem;
+}

--- a/tests/test_portales.py
+++ b/tests/test_portales.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests de integración para el Portal de Clientes y Portal de Proveedores."""
+
+import sys
+import os
+from datetime import date
+from decimal import Decimal
+
+sys.path.append(os.path.join(os.path.dirname(__file__)))
+
+from z_func import init_test_db
+from cacao_accounting import create_app
+from cacao_accounting.database import (
+    database,
+    User,
+    Party,
+    SalesInvoice,
+    SalesInvoiceItem,
+    PurchaseInvoice,
+    PurchaseInvoiceItem,
+    Entity,
+)
+from cacao_accounting.auth.roles import asigna_rol_a_usuario
+from cacao_accounting.auth import proteger_passwd
+
+app = create_app(
+    {
+        "TESTING": True,
+        "SECRET_KEY": "test-secret-key-portal",
+        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        "WTF_CSRF_ENABLED": False,
+        "DEBUG": True,
+        "PRESERVE_CONTEXT_ON_EXCEPTION": True,
+        "SQLALCHEMY_DATABASE_URI": "sqlite://",
+    }
+)
+
+
+def test_portal_security_and_access():
+    """Prueba el acceso y restricciones del Portal de Clientes y Proveedores."""
+    with app.app_context():
+        init_test_db(app)
+
+        # 1. Crear terceros (Clientes y Proveedores)
+        c1 = Party(code="CUST-001", name="Cliente 1", is_customer=True, is_active=True)
+        c2 = Party(code="CUST-002", name="Cliente 2", is_customer=True, is_active=True)
+        p1 = Party(code="SUPP-001", name="Proveedor 1", is_supplier=True, is_active=True)
+        database.session.add_all([c1, c2, p1])
+        database.session.flush()
+
+        # 2. Crear Usuarios asociados a los terceros
+        pwd = proteger_passwd("password123")
+        u_cust1 = User(user="cliente1", name="Cliente Uno", password=pwd, active=True, party_id=c1.id)
+        u_cust2 = User(user="cliente2", name="Cliente Dos", password=pwd, active=True, party_id=c2.id)
+        u_supp1 = User(user="proveedor1", name="Proveedor Uno", password=pwd, active=True, party_id=p1.id)
+        database.session.add_all([u_cust1, u_cust2, u_supp1])
+        database.session.flush()
+
+        # 3. Asignar roles especiales a los usuarios
+        asigna_rol_a_usuario("cliente1", "customer")
+        asigna_rol_a_usuario("cliente2", "customer")
+        asigna_rol_a_usuario("proveedor1", "supplier")
+
+        # 4. Crear facturas de venta y de compra para las pruebas
+        comp = database.session.execute(database.select(Entity)).scalars().first()
+        comp_code = comp.code if comp else "TEST"
+
+        inv_c1 = SalesInvoice(
+            customer_id=c1.id,
+            customer_name=c1.name,
+            company=comp_code,
+            posting_date=date.today(),
+            document_type="sales_invoice",
+            docstatus=1,
+            grand_total=Decimal("100.00"),
+        )
+        inv_c2 = SalesInvoice(
+            customer_id=c2.id,
+            customer_name=c2.name,
+            company=comp_code,
+            posting_date=date.today(),
+            document_type="sales_invoice",
+            docstatus=1,
+            grand_total=Decimal("200.00"),
+        )
+        inv_p1 = PurchaseInvoice(
+            supplier_id=p1.id,
+            supplier_name=p1.name,
+            company=comp_code,
+            posting_date=date.today(),
+            document_type="purchase_invoice",
+            docstatus=1,
+            grand_total=Decimal("500.00"),
+        )
+        database.session.add_all([inv_c1, inv_c2, inv_p1])
+        database.session.flush()
+
+        # Guardar líneas para simular detalle
+        database.session.add(
+            SalesInvoiceItem(
+                sales_invoice_id=inv_c1.id, item_code="ITM-1", qty=1, rate=Decimal("100.00"), amount=Decimal("100.00")
+            )
+        )
+        database.session.add(
+            SalesInvoiceItem(
+                sales_invoice_id=inv_c2.id, item_code="ITM-2", qty=1, rate=Decimal("200.00"), amount=Decimal("200.00")
+            )
+        )
+        database.session.add(
+            PurchaseInvoiceItem(
+                purchase_invoice_id=inv_p1.id, item_code="ITM-3", qty=1, rate=Decimal("500.00"), amount=Decimal("500.00")
+            )
+        )
+        database.session.commit()
+
+        # --- PRUEBAS CON CLIENTE 1 ---
+        with app.test_client() as client:
+            # Login
+            resp = client.post("/login", data={"usuario": "cliente1", "acceso": "password123"}, follow_redirects=True)
+            # Debe redireccionar automáticamente a /portal/customer
+            assert b"Portal del Cliente" in resp.data
+
+            # Puede acceder a su propio dashboard
+            dashboard_resp = client.get("/portal/customer")
+            assert dashboard_resp.status_code == 200
+            assert b"100.00" in dashboard_resp.data
+
+            # No debe ver la factura del cliente 2 en su listado
+            assert b"200.00" not in dashboard_resp.data
+
+            # Puede acceder al detalle de su propia factura
+            detail_resp = client.get(f"/portal/customer/invoice/{inv_c1.id}")
+            assert detail_resp.status_code == 200
+            assert b"Cliente 1" in detail_resp.data
+
+            # NO puede acceder al detalle de la factura del cliente 2 (403 Forbidden)
+            forbidden_resp = client.get(f"/portal/customer/invoice/{inv_c2.id}")
+            assert forbidden_resp.status_code == 403
+
+            # NO puede acceder al portal de proveedores (403 Forbidden)
+            no_supplier_resp = client.get("/portal/supplier")
+            assert no_supplier_resp.status_code == 403
+
+            client.get("/logout")
+
+        # --- PRUEBAS CON PROVEEDOR 1 ---
+        with app.test_client() as client:
+            # Login
+            resp = client.post("/login", data={"usuario": "proveedor1", "acceso": "password123"}, follow_redirects=True)
+            # Debe redireccionar automáticamente a /portal/supplier
+            assert b"Portal del Proveedor" in resp.data
+
+            # Puede acceder a su propio dashboard
+            dashboard_resp = client.get("/portal/supplier")
+            assert dashboard_resp.status_code == 200
+            assert b"500.00" in dashboard_resp.data
+
+            # Puede acceder al detalle de su propia factura
+            detail_resp = client.get(f"/portal/supplier/invoice/{inv_p1.id}")
+            assert detail_resp.status_code == 200
+            assert b"Proveedor 1" in detail_resp.data
+
+            # NO puede acceder al portal de clientes (403 Forbidden)
+            no_customer_resp = client.get("/portal/customer")
+            assert no_customer_resp.status_code == 403
+
+            client.get("/logout")
+
+
+def test_user_classification_and_roles_restriction():
+    """Verifica que el administrador puede seleccionar clasificación de usuario y solo 'system' puede tener roles."""
+    with app.test_client() as client:
+        # Login como administrador
+        client.post("/login", data={"usuario": "cacao", "acceso": "cacao"})
+
+        # 1. Crear un usuario de tipo customer
+        form_data = {
+            "usuario": "portal_c3",
+            "name": "Portal C3",
+            "e_mail": "c3@portal.com",
+            "classification": "customer",
+            "active": "y",
+            "password": "Password123!",
+            "confirm_password": "Password123!",
+        }
+        resp = client.post("/settings/users/new", data=form_data, follow_redirects=True)
+        assert resp.status_code == 200
+        client.get("/logout")
+
+    # Verificar fuera del bloque client
+    with app.app_context():
+        u = database.session.execute(database.select(User).filter_by(user="portal_c3")).scalar_one_or_none()
+        assert u is not None
+        assert u.classification == "customer"
+        uid = u.id
+
+    with app.test_client() as client:
+        client.post("/login", data={"usuario": "cacao", "acceso": "cacao"})
+        # Intentar asignar roles al usuario de tipo customer
+        # Debe redireccionar y mostrar la advertencia
+        roles_resp = client.post(f"/settings/users/{uid}/roles", data={"roles": []}, follow_redirects=True)
+        assert b"Solo los usuarios de tipo" in roles_resp.data
+        client.get("/logout")
+
+
+def test_portal_desktop_restriction():
+    """Verifica que el portal de clientes/proveedores esté restringido en modo Desktop."""
+    from cacao_accounting.runtime_mode import is_desktop_mode
+
+    with app.app_context():
+        # Forzar modo escritorio temporalmente en la config de la app
+        app.config["MODO_ESCRITORIO"] = True
+        try:
+            assert is_desktop_mode() is True
+
+            # Intentar login en modo escritorio como portal de cliente
+            from cacao_accounting.auth.helpers import puede_iniciar_en_escritorio
+
+            u = database.session.execute(database.select(User).filter_by(user="cliente1")).scalar_one_or_none()
+            assert u is not None
+            assert puede_iniciar_en_escritorio(u) is False
+
+            # Intentar login en modo escritorio como portal de proveedor
+            u2 = database.session.execute(database.select(User).filter_by(user="proveedor1")).scalar_one_or_none()
+            assert u2 is not None
+            assert puede_iniciar_en_escritorio(u2) is False
+
+            # Intentar acceder a rutas del portal en modo escritorio directamente
+            with app.test_client() as client:
+                client.post("/login", data={"usuario": "cliente1", "acceso": "password123"})
+                # Intentar acceder directamente a /portal/customer (debe dar 403 o no loguearse)
+                resp = client.get("/portal/customer")
+                assert resp.status_code in (403, 302)
+
+        finally:
+            # Restaurar estado
+            app.config["MODO_ESCRITORIO"] = False


### PR DESCRIPTION
We have implemented the Customer Portal and Supplier Portal features for Cloud Mode. The system now supports three classifications of users: system, customer, and supplier. Users of type 'customer' or 'supplier' are redirected automatically to their portal on login, where they can see a clean, read-only dashboard of their transactions (Sales transactions for customers, Purchase transactions for suppliers). These views strictly check that the logged-in user can only view their own transactions by matching their `party_id`. System-type users retain standard access, and only system-type users can be assigned roles. Access is disabled in Desktop Mode. Comprehensive tests were added and verified successfully.

---
*PR created automatically by Jules for task [6655930708279386954](https://jules.google.com/task/6655930708279386954) started by @williamjmorenor*