### PR TITLE
Enhance Supplier Portal with full document view and status tracking

### DIFF
--- a/cacao_accounting/portal/__init__.py
+++ b/cacao_accounting/portal/__init__.py
@@ -189,17 +189,24 @@ def supplier_dashboard():
     q_invoices = database.select(PurchaseInvoice).filter_by(
         document_type="purchase_invoice", company=current_user.company, docstatus=1
     )
+    q_notes = database.select(PurchaseInvoice).filter(
+        PurchaseInvoice.company == current_user.company,
+        PurchaseInvoice.docstatus == 1,
+        PurchaseInvoice.document_type.in_(["purchase_credit_note", "purchase_debit_note", "purchase_return"]),
+    )
     q_orders = database.select(PurchaseOrder).filter_by(company=current_user.company, docstatus=1)
     q_quotations = database.select(PurchaseQuotation).filter_by(company=current_user.company, docstatus=1)
     q_receipts = database.select(PurchaseReceipt).filter_by(company=current_user.company, docstatus=1)
 
     if not is_admin and pid:
         q_invoices = q_invoices.filter_by(supplier_id=pid)
+        q_notes = q_notes.filter_by(supplier_id=pid)
         q_orders = q_orders.filter_by(supplier_id=pid)
         q_quotations = q_quotations.filter_by(supplier_id=pid)
         q_receipts = q_receipts.filter_by(supplier_id=pid)
 
     invoices = database.session.execute(q_invoices.order_by(PurchaseInvoice.posting_date.desc())).scalars().all()
+    notes = database.session.execute(q_notes.order_by(PurchaseInvoice.posting_date.desc())).scalars().all()
     orders = database.session.execute(q_orders.order_by(PurchaseOrder.posting_date.desc())).scalars().all()
     quotations = database.session.execute(q_quotations.order_by(PurchaseQuotation.posting_date.desc())).scalars().all()
     receipts = database.session.execute(q_receipts.order_by(PurchaseReceipt.posting_date.desc())).scalars().all()
@@ -207,6 +214,7 @@ def supplier_dashboard():
     return render_template(
         "portal/supplier_dashboard.html",
         invoices=invoices,
+        notes=notes,
         orders=orders,
         quotations=quotations,
         receipts=receipts,
@@ -215,6 +223,7 @@ def supplier_dashboard():
 
 
 @portal.route("/supplier/invoice/<invoice_id>")
+@portal.route("/supplier/note/<invoice_id>")
 @login_required
 def supplier_invoice(invoice_id):
     """Detalle de factura de compra para el proveedor."""

--- a/cacao_accounting/portal/templates/portal/invoice_detail.html
+++ b/cacao_accounting/portal/templates/portal/invoice_detail.html
@@ -17,16 +17,25 @@
 </nav>
 
 {% set currency_code = document_currency_code(registro) %}
+{% set doc_type = registro.document_type or ("sales_invoice" if role == "customer" else "purchase_invoice") %}
+{% set doc_label = _('Factura de Venta') if role == 'customer' else (
+    _('Nota de Crédito') if registro.document_type == 'purchase_credit_note' else (
+    _('Nota de Débito') if registro.document_type == 'purchase_debit_note' else (
+    _('Devolución') if registro.document_type == 'purchase_return' else _('Factura de Compra')
+    ))
+) %}
+{% set status_info = document_status_info(doc_type, registro) %}
 {{ dv_macros.detail_header(
     registro.document_no or registro.id,
-    _('Factura de Venta') if role == 'customer' else _('Factura de Compra'),
-    registro.docstatus,
+    doc_label,
+    status_info,
     "",
     [
       (_('Número'), registro.document_no),
       (_('Cliente') if role == 'customer' else _('Proveedor'), registro.customer_name if role == 'customer' else registro.supplier_name),
       (_('Fecha'), registro.posting_date),
       (_('Total'), format_money_with_currency(registro.grand_total, currency_code)),
+      (_('Saldo Pendiente'), format_money_with_currency(registro.outstanding_amount, currency_code)),
       (_('Moneda'), currency_code),
       (_('Observaciones'), registro.remarks)
     ],

--- a/cacao_accounting/portal/templates/portal/order_detail.html
+++ b/cacao_accounting/portal/templates/portal/order_detail.html
@@ -17,10 +17,12 @@
 </nav>
 
 {% set currency_code = document_currency_code(registro) %}
+{% set doc_type = "sales_order" if role == "customer" else "purchase_order" %}
+{% set status_info = document_status_info(doc_type, registro) %}
 {{ dv_macros.detail_header(
     registro.document_no or registro.id,
     _('Orden de Venta') if role == 'customer' else _('Orden de Compra'),
-    registro.docstatus,
+    status_info,
     "",
     [
       (_('Número'), registro.document_no),

--- a/cacao_accounting/portal/templates/portal/quotation_detail.html
+++ b/cacao_accounting/portal/templates/portal/quotation_detail.html
@@ -17,10 +17,12 @@
 </nav>
 
 {% set currency_code = document_currency_code(registro) %}
+{% set doc_type = "sales_quotation" if role == "customer" else "purchase_quotation" %}
+{% set status_info = document_status_info(doc_type, registro) %}
 {{ dv_macros.detail_header(
     registro.document_no or registro.id,
     _('Cotización de Venta') if role == 'customer' else _('Solicitud de Cotización de Compra'),
-    registro.docstatus,
+    status_info,
     "",
     [
       (_('Número'), registro.document_no),

--- a/cacao_accounting/portal/templates/portal/receipt_detail.html
+++ b/cacao_accounting/portal/templates/portal/receipt_detail.html
@@ -17,10 +17,11 @@
 </nav>
 
 {% set currency_code = document_currency_code(registro) %}
+{% set status_info = document_status_info("purchase_receipt", registro) %}
 {{ dv_macros.detail_header(
     registro.document_no or registro.id,
     _('Recepción de Compra'),
-    registro.docstatus,
+    status_info,
     "",
     [
       (_('Número'), registro.document_no),

--- a/cacao_accounting/portal/templates/portal/supplier_dashboard.html
+++ b/cacao_accounting/portal/templates/portal/supplier_dashboard.html
@@ -5,7 +5,7 @@
   <div class="col-12">
     <div class="p-4 bg-light border rounded-3 shadow-sm">
       <h2><span class="bi bi-house-door-fill text-primary"></span> {{ _('Portal del Proveedor') }}</h2>
-      <p class="lead mb-0">{{ _('Bienvenido a su portal de servicios de lectura. Aquí puede consultar sus solicitudes de cotización, órdenes de compra, recepciones de almacén y facturas de compra.') }}</p>
+      <p class="lead mb-0">{{ _('Bienvenido a su portal de servicios de lectura. Aquí puede consultar sus solicitudes de cotización, órdenes de compra, recepciones de almacén, notas de débito y crédito, y facturas de compra.') }}</p>
     </div>
   </div>
 </div>
@@ -33,7 +33,7 @@
         <td><strong>{{ item.document_no or item.id }}</strong></td>
         <td>{{ item.posting_date }}</td>
         <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
-        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td>{{ macros.document_status_for("purchase_quotation", item) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.supplier_quotation', quotation_id=item.id) }}" class="btn btn-sm btn-outline-primary">
             <span class="bi bi-eye"></span> {{ _('Ver') }}
@@ -72,7 +72,7 @@
         <td><strong>{{ item.document_no or item.id }}</strong></td>
         <td>{{ item.posting_date }}</td>
         <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
-        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td>{{ macros.document_status_for("purchase_order", item) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.supplier_order', order_id=item.id) }}" class="btn btn-sm btn-outline-primary">
             <span class="bi bi-eye"></span> {{ _('Ver') }}
@@ -111,7 +111,7 @@
         <td><strong>{{ item.document_no or item.id }}</strong></td>
         <td>{{ item.posting_date }}</td>
         <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
-        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td>{{ macros.document_status_for("purchase_receipt", item) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.supplier_receipt', receipt_id=item.id) }}" class="btn btn-sm btn-outline-primary">
             <span class="bi bi-eye"></span> {{ _('Ver') }}
@@ -121,6 +121,57 @@
       {% else %}
       <tr>
         <td colspan="5" class="text-center text-muted py-3">{{ _('No se encontraron recepciones.') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+<!-- Notas de Débito y Crédito -->
+<div class="portal-section-header d-flex justify-content-between align-items-center">
+  <h4><span class="bi bi-file-earmark-diff text-info me-2" aria-hidden="true"></span>{{ _('Notas de Débito y Crédito') }}</h4>
+  <span class="badge bg-secondary">{{ notes|length }}</span>
+</div>
+<div class="table-responsive bg-white border rounded shadow-sm mb-4">
+  <table class="table table-hover align-middle mb-0">
+    <caption class="visually-hidden">{{ _('Notas de Débito y Crédito') }}</caption>
+    <thead class="table-light">
+      <tr>
+        <th scope="col">{{ _('Número') }}</th>
+        <th scope="col">{{ _('Tipo') }}</th>
+        <th scope="col">{{ _('Fecha') }}</th>
+        <th scope="col" class="text-end">{{ _('Total') }}</th>
+        <th scope="col">{{ _('Estado') }}</th>
+        <th scope="col" class="text-center" style="width: 10%;">{{ _('Acción') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in notes %}
+      <tr>
+        <td><strong>{{ item.document_no or item.id }}</strong></td>
+        <td>
+          {% if item.document_type == 'purchase_credit_note' %}
+            <span class="badge text-bg-info">{{ _('Nota de Crédito') }}</span>
+          {% elif item.document_type == 'purchase_debit_note' %}
+            <span class="badge text-bg-warning">{{ _('Nota de Débito') }}</span>
+          {% elif item.document_type == 'purchase_return' %}
+            <span class="badge text-bg-secondary">{{ _('Devolución') }}</span>
+          {% else %}
+            <span class="badge text-bg-light">{{ item.document_type }}</span>
+          {% endif %}
+        </td>
+        <td>{{ item.posting_date }}</td>
+        <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
+        <td>{{ macros.document_status_for(item.document_type or "purchase_invoice", item) }}</td>
+        <td class="text-center">
+          <a href="{{ url_for('portal.supplier_invoice', invoice_id=item.id) }}" class="btn btn-sm btn-outline-primary">
+            <span class="bi bi-eye"></span> {{ _('Ver') }}
+          </a>
+        </td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="6" class="text-center text-muted py-3">{{ _('No se encontraron notas de débito o crédito.') }}</td>
       </tr>
       {% endfor %}
     </tbody>
@@ -150,7 +201,7 @@
         <td><strong>{{ item.document_no or item.id }}</strong></td>
         <td>{{ item.posting_date }}</td>
         <td class="text-end">{{ format_money_with_currency(item.grand_total, document_currency_code(item)) }}</td>
-        <td>{{ macros.docstatus_badge(item.docstatus) }}</td>
+        <td>{{ macros.document_status_for("purchase_invoice", item) }}</td>
         <td class="text-center">
           <a href="{{ url_for('portal.supplier_invoice', invoice_id=item.id) }}" class="btn btn-sm btn-outline-primary">
             <span class="bi bi-eye"></span> {{ _('Ver') }}

--- a/cacao_accounting/templates/detail_view_macros.html
+++ b/cacao_accounting/templates/detail_view_macros.html
@@ -1,7 +1,10 @@
 {% macro detail_header(document_title, document_type_label, status_value, buttons_html, items, icon) %}
 {% set status_badge = 'bg-secondary' %}
 {% set status_label = _('draft') %}
-{% if status_value == 'submitted' or status_value == 1 %}
+{% if status_value and status_value.badge_class is defined %}
+    {% set status_badge = status_value.badge_class %}
+    {% set status_label = status_value.label %}
+{% elif status_value == 'submitted' or status_value == 1 %}
     {% set status_badge = 'bg-success' %}
     {% set status_label = _('submitted') %}
 {% elif status_value == 'rejected' %}

--- a/tests/test_portales.py
+++ b/tests/test_portales.py
@@ -19,6 +19,12 @@ from cacao_accounting.database import (
     SalesInvoiceItem,
     PurchaseInvoice,
     PurchaseInvoiceItem,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    PurchaseQuotation,
+    PurchaseQuotationItem,
+    PurchaseReceipt,
+    PurchaseReceiptItem,
     Entity,
 )
 from cacao_accounting.auth.roles import asigna_rol_a_usuario
@@ -233,6 +239,151 @@ def test_user_classification_and_roles_restriction():
         roles_resp = client.post(f"/settings/users/{uid}/roles", data={"roles": []}, follow_redirects=True)
         assert b"Solo los usuarios de tipo" in roles_resp.data
         client.get("/logout")
+
+
+def test_supplier_portal_full_functionality():
+    """Prueba exhaustiva para la funcionalidad completa del Portal del Proveedor."""
+    with app.app_context():
+        init_test_db(app)
+
+        comp = database.session.execute(database.select(Entity)).scalars().first()
+        comp_code = comp.code if comp else "TEST"
+
+        # 1. Crear dos proveedores y sus usuarios portal
+        p1 = Party(code="SUP-001", name="Proveedor Alfa", is_supplier=True, is_active=True)
+        p2 = Party(code="SUP-002", name="Proveedor Beta", is_supplier=True, is_active=True)
+        database.session.add_all([p1, p2])
+        database.session.flush()
+
+        pwd = proteger_passwd("password123")
+        u_p1 = User(
+            user="supplier_alfa",
+            name="Alfa User",
+            password=pwd,
+            active=True,
+            party_id=p1.id,
+            classification="supplier",
+            company=comp_code,
+        )
+        u_p2 = User(
+            user="supplier_beta",
+            name="Beta User",
+            password=pwd,
+            active=True,
+            party_id=p2.id,
+            classification="supplier",
+            company=comp_code,
+        )
+        database.session.add_all([u_p1, u_p2])
+        database.session.flush()
+
+        asigna_rol_a_usuario("supplier_alfa", "supplier")
+        asigna_rol_a_usuario("supplier_beta", "supplier")
+
+        # 2. Crear las 5 categorías de documentos para Proveedor 1 (Alfa) con docstatus=1
+        q_alfa = PurchaseQuotation(
+            supplier_id=p1.id, supplier_name=p1.name, company=comp_code, posting_date=date.today(), docstatus=1, grand_total=Decimal("150.00")
+        )
+        o_alfa = PurchaseOrder(
+            supplier_id=p1.id, supplier_name=p1.name, company=comp_code, posting_date=date.today(), docstatus=1, grand_total=Decimal("250.00")
+        )
+        r_alfa = PurchaseReceipt(
+            supplier_id=p1.id, supplier_name=p1.name, company=comp_code, posting_date=date.today(), docstatus=1, grand_total=Decimal("350.00")
+        )
+        note_alfa = PurchaseInvoice(
+            supplier_id=p1.id,
+            supplier_name=p1.name,
+            company=comp_code,
+            posting_date=date.today(),
+            document_type="purchase_credit_note",
+            docstatus=1,
+            grand_total=Decimal("50.00"),
+        )
+        inv_alfa = PurchaseInvoice(
+            supplier_id=p1.id,
+            supplier_name=p1.name,
+            company=comp_code,
+            posting_date=date.today(),
+            document_type="purchase_invoice",
+            docstatus=1,
+            grand_total=Decimal("450.00"),
+        )
+
+        # 3. Crear documentos Borradores (docstatus=0) y Anulados (docstatus=2) para Alfa
+        draft_inv = PurchaseInvoice(
+            supplier_id=p1.id,
+            supplier_name=p1.name,
+            company=comp_code,
+            posting_date=date.today(),
+            document_type="purchase_invoice",
+            docstatus=0,
+            grand_total=Decimal("999.00"),
+        )
+        cancelled_inv = PurchaseInvoice(
+            supplier_id=p1.id,
+            supplier_name=p1.name,
+            company=comp_code,
+            posting_date=date.today(),
+            document_type="purchase_invoice",
+            docstatus=2,
+            grand_total=Decimal("888.00"),
+        )
+
+        # 4. Crear documento para Proveedor 2 (Beta) con docstatus=1
+        inv_beta = PurchaseInvoice(
+            supplier_id=p2.id,
+            supplier_name=p2.name,
+            company=comp_code,
+            posting_date=date.today(),
+            document_type="purchase_invoice",
+            docstatus=1,
+            grand_total=Decimal("777.00"),
+        )
+
+        database.session.add_all([q_alfa, o_alfa, r_alfa, note_alfa, inv_alfa, draft_inv, cancelled_inv, inv_beta])
+        database.session.flush()
+
+        # Añadir items para detalle
+        database.session.add(PurchaseQuotationItem(purchase_quotation_id=q_alfa.id, item_code="ITM-Q", qty=1, rate=Decimal("150.00"), amount=Decimal("150.00")))
+        database.session.add(PurchaseOrderItem(purchase_order_id=o_alfa.id, item_code="ITM-O", qty=1, rate=Decimal("250.00"), amount=Decimal("250.00")))
+        database.session.add(PurchaseReceiptItem(purchase_receipt_id=r_alfa.id, item_code="ITM-R", qty=1, rate=Decimal("350.00"), amount=Decimal("350.00")))
+        database.session.add(PurchaseInvoiceItem(purchase_invoice_id=note_alfa.id, item_code="ITM-N", qty=1, rate=Decimal("50.00"), amount=Decimal("50.00")))
+        database.session.add(PurchaseInvoiceItem(purchase_invoice_id=inv_alfa.id, item_code="ITM-I", qty=1, rate=Decimal("450.00"), amount=Decimal("450.00")))
+        database.session.commit()
+
+        # Pruebas como Proveedor Alfa
+        with app.test_client() as client:
+            client.post("/login", data={"usuario": "supplier_alfa", "acceso": "password123"}, follow_redirects=True)
+
+            dash = client.get("/portal/supplier")
+            assert dash.status_code == 200
+            # Debe mostrar las 5 categorías de Alfa
+            assert b"150.00" in dash.data  # Quotation
+            assert b"250.00" in dash.data  # Order
+            assert b"350.00" in dash.data  # Receipt
+            assert b"50.00" in dash.data   # Credit Note
+            assert b"450.00" in dash.data  # Invoice
+
+            # NO debe mostrar borradores (999.00), ni anulados (888.00), ni transacciones de Beta (777.00)
+            assert b"999.00" not in dash.data
+            assert b"888.00" not in dash.data
+            assert b"777.00" not in dash.data
+
+            # Verificar rutas de detalle
+            assert client.get(f"/portal/supplier/quotation/{q_alfa.id}").status_code == 200
+            assert client.get(f"/portal/supplier/order/{o_alfa.id}").status_code == 200
+            assert client.get(f"/portal/supplier/receipt/{r_alfa.id}").status_code == 200
+            assert client.get(f"/portal/supplier/invoice/{inv_alfa.id}").status_code == 200
+            assert client.get(f"/portal/supplier/note/{note_alfa.id}").status_code == 200
+
+            # Detalle de borrador o anulado da 404
+            assert client.get(f"/portal/supplier/invoice/{draft_inv.id}").status_code == 404
+            assert client.get(f"/portal/supplier/invoice/{cancelled_inv.id}").status_code == 404
+
+            # Acceso a documento de otro proveedor da 403
+            assert client.get(f"/portal/supplier/invoice/{inv_beta.id}").status_code == 403
+
+            client.get("/logout")
 
 
 def test_portal_desktop_restriction():


### PR DESCRIPTION
Reviewed and enhanced the Supplier Portal functionality:
- Added 'Notas de Débito y Crédito' section and view route (/supplier/note/<invoice_id>).
- Enforced strict docstatus=1 filtering across supplier dashboard and detail endpoints (excluding draft docstatus=0 and cancelled docstatus=2 records).
- Enforced party_id and company isolation for non-admin supplier portal users.
- Updated status badges across supplier dashboard and detail views to display calculated business statuses (e.g., Pendiente Pagar, Recibido Parcialmente, Abierto).
- Added comprehensive unit tests and verified frontend visual rendering via Playwright.

---
*PR created automatically by Jules for task [10442108540812154414](https://jules.google.com/task/10442108540812154414) started by @williamjmorenor*