### PR TITLE
Add operational transaction email notifications, queue, and admin log

### DIFF
--- a/cacao_accounting/admin/__init__.py
+++ b/cacao_accounting/admin/__init__.py
@@ -253,6 +253,7 @@ def _save_email_settings() -> None:
         "smtp_user": (request.form.get("smtp_user") or "").strip(),
         "smtp_use_tls": "true" if request.form.get("smtp_use_tls") == "on" else "false",
         "smtp_from_email": (request.form.get("smtp_from_email") or "").strip(),
+        "disable_transaction_emails": "true" if request.form.get("disable_transaction_emails") == "on" else "false",
     }
     for key, value in settings.items():
         set_smtp_setting(key, value)
@@ -272,6 +273,7 @@ def _email_settings_values() -> dict[str, str]:
         "smtp_user": get_smtp_setting("smtp_user") or "",
         "smtp_use_tls": get_smtp_setting("smtp_use_tls") or "true",
         "smtp_from_email": get_smtp_setting("smtp_from_email") or "",
+        "disable_transaction_emails": get_smtp_setting("disable_transaction_emails") or "false",
     }
 
 
@@ -301,8 +303,69 @@ def email_settings():
         smtp_user=settings["smtp_user"],
         smtp_use_tls=settings["smtp_use_tls"].lower() in ("true", "1", "yes", "y", "on"),
         smtp_from_email=settings["smtp_from_email"],
+        disable_transaction_emails=settings["disable_transaction_emails"].lower() in ("true", "1", "yes", "y", "on"),
         titulo=_("Configuración de Correo Electrónico"),
     )
+
+
+@admin.route("/settings/email-log")
+@login_required
+@modulo_activo("admin")
+def email_log():
+    """Muestra la bitácora y cola de correos electrónicos del sistema (Cloud-Only)."""
+    _require_system_admin()
+    if is_desktop_mode():
+        abort(403)
+
+    from cacao_accounting.database import EmailQueue
+
+    page = request.args.get("page", 1, type=int)
+    search = (request.args.get("search") or "").strip()
+    status_filter = (request.args.get("status") or "").strip()
+
+    query = database.select(EmailQueue)
+
+    if search:
+        query = query.where(
+            EmailQueue.recipient.ilike(f"%{search}%")
+            | EmailQueue.subject.ilike(f"%{search}%")
+            | EmailQueue.document_id.ilike(f"%{search}%")
+        )
+
+    if status_filter:
+        query = query.where(EmailQueue.status == status_filter)
+
+    query = query.order_by(EmailQueue.created.desc())
+
+    consulta = database.paginate(query, page=page, per_page=20)
+
+    return render_template(
+        "admin/email_log.html",
+        consulta=consulta,
+        titulo=_("Bitácora de Correos Electrónicos"),
+    )
+
+
+@admin.route("/settings/email-log/<queue_id>/retry", methods=["POST"])
+@login_required
+@modulo_activo("admin")
+def email_log_retry(queue_id: str):
+    """Reintenta el envío de un correo electrónico desde la bitácora."""
+    _require_system_admin()
+    if is_desktop_mode():
+        abort(403)
+
+    from cacao_accounting.messaging.email import retry_email_queue_item, EmailError
+
+    try:
+        retry_email_queue_item(queue_id)
+        flash(_("Correo reenviado exitosamente."), "success")
+    except EmailError as exc:
+        flash(_(str(exc)), "danger")
+    except Exception as exc:
+        flash(_(f"Error al reintentar envío: {exc}"), "danger")
+
+    return redirect(url_for("admin.email_log"))
 
 
 @admin.route("/settings/inventory-valuation", methods=["GET", "POST"])

--- a/cacao_accounting/admin/navigation.py
+++ b/cacao_accounting/admin/navigation.py
@@ -40,6 +40,7 @@ CONFIGURATION_SECTIONS: tuple[ConfigurationSection, ...] = (
             ),
             ConfigurationLink("admin.external_document_validation_settings", "Validación externa de documentos"),
             ConfigurationLink("admin.email_settings", "Correo electrónico", cloud_only=True),
+            ConfigurationLink("admin.email_log", "Bitácora de correos", cloud_only=True),
             ConfigurationLink("admin.lista_grupos_terceros", "Tipos de terceros"),
             ConfigurationLink("admin.lista_precios", "Listas de precios"),
             ConfigurationLink("admin.precios_item", "Precios por artículo"),

--- a/cacao_accounting/admin/templates/admin/email_log.html
+++ b/cacao_accounting/admin/templates/admin/email_log.html
@@ -1,0 +1,134 @@
+{% extends "base.html" %}
+{% block contenido %}
+{% import "macros.html" as macros %}
+
+{% if TESTING %}
+<div data-test_info="La Plantilla fue renderizada correctamente: cacao_accounting/admin/templates/admin/email_log.html"></div>
+{% endif %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb lh-sm">
+    <li class="breadcrumb-item"><a href="{{ url_for('admin.admin_') }}" class="link-dark">{{ _("Configuración") }}</a></li>
+    <li class="breadcrumb-item active" aria-current="page">{{ _("Bitácora de Correos Electrónicos") }}</li>
+  </ol>
+</nav>
+
+<div class="ca-page-header mb-3">
+  <h4><i class="bi bi-envelope-paper me-2" style="color:#78BF30"></i>{{ _("Bitácora de Correos Electrónicos") }}</h4>
+</div>
+
+<div class="ca-card">
+  <div class="ca-card-header">
+    <h6 class="ca-card-title mb-0"><i class="bi bi-clock-history me-1"></i>{{ _("Historial y Cola de Correos") }}</h6>
+    <div class="d-flex gap-2">
+      <a href="{{ url_for('admin.email_settings') }}" class="btn btn-sm btn-outline-secondary">
+        <i class="bi bi-gear me-1"></i>{{ _("Ajustes SMTP") }}
+      </a>
+    </div>
+  </div>
+
+  <div class="p-3 border-bottom">
+    <form method="get" action="{{ url_for('admin.email_log') }}" class="row g-2 align-items-end">
+      <div class="col-md-5">
+        <label class="form-label small text-muted mb-1" for="list-search">{{ _('Buscar') }}</label>
+        <input
+          type="text"
+          id="list-search"
+          name="search"
+          class="form-control form-control-sm"
+          placeholder="{{ _('Buscar por destinatario, asunto o documento...') }}"
+          value="{{ request.args.get('search', '') }}"
+        >
+      </div>
+      <div class="col-md-3">
+        <label class="form-label small text-muted mb-1" for="list-status">{{ _('Estado') }}</label>
+        <select id="list-status" name="status" class="form-select form-select-sm">
+          <option value="">{{ _('Todos') }}</option>
+          <option value="sent" {% if request.args.get('status') == 'sent' %}selected{% endif %}>{{ _('Enviado') }}</option>
+          <option value="failed" {% if request.args.get('status') == 'failed' %}selected{% endif %}>{{ _('Fallido') }}</option>
+          <option value="pending" {% if request.args.get('status') == 'pending' %}selected{% endif %}>{{ _('Pendiente') }}</option>
+        </select>
+      </div>
+      <div class="col-auto">
+        <button type="submit" class="btn btn-sm btn-primary"><i class="bi bi-search me-1"></i>{{ _('Buscar') }}</button>
+        <a href="{{ url_for('admin.email_log') }}" class="btn btn-sm btn-outline-secondary">{{ _('Limpiar') }}</a>
+      </div>
+    </form>
+  </div>
+
+  <div class="table-responsive">
+    <table class="ca-table mb-0">
+      <caption class="visually-hidden">{{ _("Bitácora de Correos Electrónicos") }}</caption>
+      <thead>
+        <tr>
+          <th>{{ _("Fecha") }}</th>
+          <th>{{ _("Destinatario") }}</th>
+          <th>{{ _("Asunto") }}</th>
+          <th>{{ _("Documento") }}</th>
+          <th>{{ _("Estado") }}</th>
+          <th class="text-center">{{ _("Intentos") }}</th>
+          <th>{{ _("Detalles / Error") }}</th>
+          <th class="text-end">{{ _("Acciones") }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in consulta.items %}
+        <tr>
+          <td class="small">{{ item.created.strftime('%Y-%m-%d %H:%M') if item.created else '-' }}</td>
+          <td><strong>{{ item.recipient }}</strong></td>
+          <td class="small">{{ item.subject }}</td>
+          <td class="small">
+            {% if item.document_type and item.document_id %}
+            <span class="badge bg-light text-dark">{{ item.document_type }}: {{ item.document_id }}</span>
+            {% else %}
+            -
+            {% endif %}
+          </td>
+          <td>
+            {% if item.status == 'sent' %}
+            <span class="badge bg-success"><i class="bi bi-check-circle me-1"></i>{{ _("Enviado") }}</span>
+            {% elif item.status == 'failed' %}
+            <span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>{{ _("Fallido") }}</span>
+            {% else %}
+            <span class="badge bg-warning text-dark"><i class="bi bi-hourglass-split me-1"></i>{{ _("Pendiente") }}</span>
+            {% endif %}
+          </td>
+          <td class="text-center">{{ item.attempts or 0 }}</td>
+          <td class="small text-muted" style="max-width:250px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;" title="{{ item.error_message or '' }}">
+            {% if item.error_message %}
+            <span class="text-danger">{{ item.error_message }}</span>
+            {% elif item.sent_at %}
+            <span class="text-success">{{ _("Enviado el") }} {{ item.sent_at.strftime('%Y-%m-%d %H:%M') }}</span>
+            {% else %}
+            -
+            {% endif %}
+          </td>
+          <td class="text-end">
+            {% if item.status == 'failed' or item.status == 'pending' %}
+            <form method="post" action="{{ url_for('admin.email_log_retry', queue_id=item.id) }}" class="d-inline">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button type="submit" class="btn btn-sm btn-outline-primary" title="{{ _('Reintentar envío de correo') }}">
+                <i class="bi bi-arrow-repeat me-1"></i>{{ _("Reintentar") }}
+              </button>
+            </form>
+            {% else %}
+            <button class="btn btn-sm btn-outline-secondary" disabled title="{{ _('Correo ya enviado') }}">
+              <i class="bi bi-check2 me-1"></i>{{ _("Enviado") }}
+            </button>
+            {% endif %}
+          </td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="8" class="text-center text-muted py-4">
+            <i class="bi bi-inbox me-2"></i>{{ _("No hay registros de correos electrónicos en la bitácora.") }}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+{{ macros.rendizar_paginacion(consulta, 'admin.email_log') }}
+{% endblock %}

--- a/cacao_accounting/api/__init__.py
+++ b/cacao_accounting/api/__init__.py
@@ -256,6 +256,124 @@ def api_fiscal_preview():
     return jsonify(result)
 
 
+@api.route("/api/documents/<document_type>/<document_id>/email-info")
+@login_required
+def api_document_email_info(document_type: str, document_id: str):
+    """Devuelve la información predeterminada para redactar el correo de un documento."""
+    from cacao_accounting.messaging.email import can_send_transaction_emails, get_document_default_recipient_email
+
+    if not can_send_transaction_emails():
+        return jsonify({"enabled": False, "error": _("El envío de correos no está disponible.")}), 403
+
+    doc = _require_document_read_access(document_type, document_id)
+    default_recipient = get_document_default_recipient_email(document_type, document_id)
+    doc_no = getattr(doc, "document_no", None) or document_id
+    company = getattr(doc, "company", None) or ""
+
+    return jsonify(
+        {
+            "enabled": True,
+            "default_recipient": default_recipient,
+            "document_no": doc_no,
+            "subject": f"Notificación de documento #{doc_no}",
+            "body": (
+                f"Estimado(a),\n\nLe compartimos la información correspondiente "
+                f"al documento #{doc_no}.\n\nSaludos cordiales,\n{company}"
+            ),
+        }
+    )
+
+
+@api.route("/api/documents/<document_type>/<document_id>/email", methods=["POST"])
+@login_required
+def api_document_send_email(document_type: str, document_id: str):
+    """Envía una notificación por correo electrónico para un documento operativo."""
+    import re
+    from datetime import datetime, timezone
+    from cacao_accounting.database import EmailQueue
+    from cacao_accounting.messaging.email import can_send_transaction_emails, EmailError, send_email
+    from cacao_accounting.audit_trail_service import log_email_sent
+
+    if not can_send_transaction_emails():
+        return jsonify({"error": _("El envío de correos electrónicos no está habilitado o no está configurado.")}), 403
+
+    doc = _require_document_read_access(document_type, document_id)
+
+    payload = request.get_json(silent=True) or request.form.to_dict()
+    raw_recipients = payload.get("recipients") or payload.get("recipient") or ""
+    subject = str(payload.get("subject") or "").strip()
+    body = str(payload.get("body") or payload.get("message") or "").strip()
+
+    if isinstance(raw_recipients, list):
+        recipient_list = [str(r).strip() for r in raw_recipients if str(r).strip()]
+    else:
+        recipient_list = [r.strip() for r in re.split(r"[,;]", str(raw_recipients)) if r.strip()]
+
+    if not recipient_list:
+        return jsonify({"error": _("Debe especificar al menos un destinatario válido.")}), 400
+
+    doc_no = getattr(doc, "document_no", None) or document_id
+    company = getattr(doc, "company", None) or ""
+
+    if not subject:
+        subject = f"Notificación de documento #{doc_no}"
+
+    if not body:
+        body = f"Estimado(a),\n\nSe le notifica la emisión del documento #{doc_no}.\n\nAtentamente,\n{company}"
+
+    sent_count = 0
+    errors = []
+
+    for to_email in recipient_list:
+        queue_item = EmailQueue(
+            document_type=document_type,
+            document_id=document_id,
+            recipient=to_email,
+            subject=subject,
+            body=body,
+            status="pending",
+            attempts=1,
+        )
+        database.session.add(queue_item)
+        database.session.flush()
+
+        try:
+            send_email(to_email=to_email, subject=subject, body=body, is_html=False)
+            queue_item.status = "sent"
+            queue_item.sent_at = datetime.now(timezone.utc)
+            sent_count += 1
+        except EmailError as exc:
+            queue_item.status = "failed"
+            queue_item.error_message = str(exc)
+            errors.append(f"{to_email}: {exc}")
+        except Exception as exc:
+            queue_item.status = "failed"
+            queue_item.error_message = str(exc)
+            errors.append(f"{to_email}: {exc}")
+
+    if sent_count > 0:
+        recipients_str = ", ".join(recipient_list)
+        log_email_sent(
+            doc,
+            recipients=recipients_str,
+            subject=subject,
+            comment=f"correo enviado exitosamente a {recipients_str}",
+        )
+        database.session.commit()
+        return jsonify(
+            {
+                "success": True,
+                "message": _("Correo enviado exitosamente."),
+                "sent_count": sent_count,
+                "recipients": recipient_list,
+            }
+        )
+    else:
+        database.session.commit()
+        error_msg = "; ".join(errors) if errors else _("No se pudo enviar el correo.")
+        return jsonify({"error": error_msg}), 500
+
+
 @api.route("/api/documents/<document_type>/<document_id>/comments", methods=["POST"])
 @login_required
 def api_document_comment(document_type: str, document_id: str):

--- a/cacao_accounting/audit_trail_service.py
+++ b/cacao_accounting/audit_trail_service.py
@@ -43,6 +43,7 @@ ALLOWED_ACTIONS = {
     "balance_confirmation_disputed",
     "balance_confirmation_cancelled",
     "balance_confirmation_expired",
+    "email_sent",
 }
 
 
@@ -219,6 +220,17 @@ def log_delete_attempt(document: Any) -> AuditTrail:
 def log_comment(document: Any, comment: str) -> AuditTrail:
     """Log a user comment on a document."""
     return _log("commented", document, after=document, comment=comment)
+
+
+def log_email_sent(
+    document: Any,
+    recipients: str,
+    subject: str,
+    comment: str | None = None,
+) -> AuditTrail:
+    """Log an audit trail entry when a transaction email is sent successfully."""
+    msg = comment or f"correo enviado exitosamente a {recipients} (Asunto: {subject})"
+    return _log("email_sent", document, after=document, comment=msg)
 
 
 def log_task_event(document: Any, action: str, comment: str) -> AuditTrail:

--- a/cacao_accounting/database/__init__.py
+++ b/cacao_accounting/database/__init__.py
@@ -4579,6 +4579,21 @@ class AuditTrail(database.Model):  # type: ignore[name-defined]
     user_agent = database.Column(database.String(512), nullable=True)
 
 
+class EmailQueue(database.Model, BaseTabla):  # type: ignore[name-defined]
+    """Cola de correos electrónicos y registro de notificaciones del sistema."""
+
+    __tablename__ = "email_queue"
+    document_type = database.Column(database.String(80), nullable=True, index=True)
+    document_id = database.Column(database.String(50), nullable=True, index=True)
+    recipient = database.Column(database.String(255), nullable=False)
+    subject = database.Column(database.String(255), nullable=False)
+    body = database.Column(database.Text(), nullable=False)
+    status = database.Column(database.String(20), nullable=False, default="pending", index=True)
+    error_message = database.Column(database.Text(), nullable=True)
+    attempts = database.Column(database.Integer(), nullable=False, default=0)
+    sent_at = database.Column(database.DateTime(timezone=True), nullable=True)
+
+
 class DocumentTask(database.Model, BaseTabla):  # type: ignore[name-defined]
     """Lightweight cloud task assigned to a document."""
 

--- a/cacao_accounting/messaging/email.py
+++ b/cacao_accounting/messaging/email.py
@@ -179,6 +179,99 @@ def _send_smtp_message(
     smtp.quit()
 
 
+def retry_email_queue_item(queue_id: str) -> Any:
+    """Reintenta el envío de un correo fallido desde la cola de correos."""
+    from datetime import datetime, timezone
+    from cacao_accounting.database import EmailQueue
+
+    if is_desktop_mode():
+        raise EmailError("El reintento de envío de correos no está disponible en modo DESKTOP.")
+
+    item = database.session.get(EmailQueue, queue_id)
+    if not item:
+        raise EmailError("El registro de correo no existe.")
+
+    item.attempts = (item.attempts or 0) + 1
+    try:
+        send_email(to_email=item.recipient, subject=item.subject, body=item.body, is_html=False)
+        item.status = "sent"
+        item.error_message = None
+        item.sent_at = datetime.now(timezone.utc)
+
+        if item.document_type and item.document_id:
+            try:
+                from cacao_accounting.document_flow.repository import get_document
+                from cacao_accounting.audit_trail_service import log_email_sent
+
+                doc = get_document(item.document_type, item.document_id)
+                if doc:
+                    log_email_sent(
+                        doc,
+                        recipients=item.recipient,
+                        subject=item.subject,
+                        comment=f"correo reintentado y enviado exitosamente a {item.recipient}",
+                    )
+            except Exception as audit_exc:
+                LOGGER.warning("No se pudo registrar auditoría en reintento: %s", audit_exc)
+
+        database.session.commit()
+        return item
+    except Exception as exc:
+        item.status = "failed"
+        item.error_message = str(exc)
+        database.session.commit()
+        raise EmailError(f"Error al reintentar envío: {exc}") from exc
+
+
+def can_send_transaction_emails() -> bool:
+    """Verifica si el envío de correos desde transacciones operativas está habilitado y configurado."""
+    if is_desktop_mode():
+        return False
+    server = get_smtp_setting("smtp_server")
+    from_email = get_smtp_setting("smtp_from_email")
+    if not server or not from_email:
+        return False
+    disabled = _get_db_value("disable_transaction_emails")
+    if disabled and disabled.lower() in ("true", "1", "yes", "y", "on"):
+        return False
+    return True
+
+
+def get_document_default_recipient_email(document_type: str, document_id: str) -> str:
+    """Obtiene la dirección de correo del proveedor/cliente o tercero asociado al documento."""
+    if not has_app_context():
+        return ""
+    try:
+        from cacao_accounting.document_flow.repository import get_document
+        from cacao_accounting.database import Party, database
+
+        doc = get_document(document_type, document_id)
+        if not doc:
+            return ""
+
+        party_id = (
+            getattr(doc, "supplier_id", None)
+            or getattr(doc, "customer_id", None)
+            or getattr(doc, "client_id", None)
+            or getattr(doc, "party_id", None)
+            or getattr(doc, "entity_id", None)
+        )
+        if not party_id:
+            return ""
+
+        tercero = database.session.execute(
+            database.select(Party).where((Party.id == str(party_id)) | (Party.code == str(party_id)))
+        ).scalar_one_or_none()
+
+        if tercero:
+            email = (tercero.primary_email or tercero.legal_representative_email or "").strip()
+            if email:
+                return email
+    except Exception:
+        pass
+    return ""
+
+
 def send_email(to_email: str, subject: str, body: str, is_html: bool = False) -> None:
     """Envía un correo electrónico utilizando la configuración SMTP activa (Cloud-Only)."""
     if is_desktop_mode():

--- a/cacao_accounting/templates/macros.html
+++ b/cacao_accounting/templates/macros.html
@@ -521,6 +521,133 @@
 </div>
 {% endmacro %}
 
+{# ─── Email Notification Shortcuts ────────────────────────────── #}
+{% macro document_email_button(document_type, document) %}
+{% if can_send_transaction_emails() %}
+<button class="btn btn-sm btn-outline-primary"
+        type="button"
+        data-bs-toggle="modal"
+        data-bs-target="#emailNotificationModal"
+        title="{{ _('Notificar por correo electrónico') }}">
+  <i class="bi bi-envelope me-1"></i>{{ _('Notificar por correo') }}
+</button>
+{% endif %}
+{% endmacro %}
+
+{% macro document_email_modal(document_type, document) %}
+{% if can_send_transaction_emails() %}
+<div class="modal fade" id="emailNotificationModal" tabindex="-1" aria-labelledby="emailNotificationModalLabel" aria-hidden="true"
+     x-data="{
+       recipients: '',
+       subject: '',
+       body: '',
+       loading: false,
+       infoLoaded: false,
+       alertMessage: '',
+       alertType: 'success',
+       loadInfo() {
+         if (this.infoLoaded) return;
+         this.loading = true;
+         fetch('/api/documents/{{ document_type }}/{{ document.id }}/email-info', { credentials: 'same-origin' })
+           .then(r => r.json())
+           .then(data => {
+             this.loading = false;
+             this.infoLoaded = true;
+             if (data.enabled) {
+               this.recipients = data.default_recipient || '';
+               this.subject = data.subject || 'Notificación de documento';
+               this.body = data.body || '';
+             }
+           })
+           .catch(() => { this.loading = false; });
+       },
+       sendEmail() {
+         if (!this.recipients.trim()) {
+           this.alertType = 'danger';
+           this.alertMessage = '{{ _("Ingrese al menos un correo de destinatario.") }}';
+           return;
+         }
+         this.loading = true;
+         this.alertMessage = '';
+         fetch('/api/documents/{{ document_type }}/{{ document.id }}/email', {
+           method: 'POST',
+           headers: {
+             'Content-Type': 'application/json',
+             'X-CSRFToken': '{{ csrf_token() }}'
+           },
+           credentials: 'same-origin',
+           body: JSON.stringify({
+             recipients: this.recipients,
+             subject: this.subject,
+             body: this.body
+           })
+         })
+         .then(r => r.json().then(d => ({ status: r.status, body: d })))
+         .then(res => {
+           this.loading = false;
+           if (res.status === 200 && res.body.success) {
+             this.alertType = 'success';
+             this.alertMessage = res.body.message || '{{ _("Correo enviado exitosamente.") }}';
+             setTimeout(() => {
+               var modalEl = document.getElementById('emailNotificationModal');
+               var modal = bootstrap.Modal.getInstance(modalEl);
+               if (modal) modal.hide();
+               window.location.reload();
+             }, 1500);
+           } else {
+             this.alertType = 'danger';
+             this.alertMessage = res.body.error || '{{ _("Error al enviar el correo.") }}';
+           }
+         })
+         .catch(() => {
+           this.loading = false;
+           this.alertType = 'danger';
+           this.alertMessage = '{{ _("Error de conexión al enviar el correo.") }}';
+         });
+       }
+     }"
+     x-init="$el.addEventListener('shown.bs.modal', () => loadInfo())">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="emailNotificationModalLabel">
+          <i class="bi bi-envelope me-2" style="color:#78BF30"></i>{{ _("Notificar por Correo Electrónico") }}
+        </h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ _('Cerrar') }}"></button>
+      </div>
+      <div class="modal-body">
+        <div x-show="alertMessage" class="alert mb-3" :class="'alert-' + alertType" x-text="alertMessage"></div>
+
+        <div class="mb-3">
+          <label class="form-label small fw-semibold" for="email-recipients">{{ _("Destinatarios (separados por coma)") }}</label>
+          <input type="text" class="form-control form-control-sm" id="email-recipients" x-model="recipients" placeholder="proveedor@ejemplo.com, cliente@ejemplo.com" :disabled="loading">
+          <div class="form-text text-muted">{{ _("Sugerido automáticamente desde la ficha del tercero. Puede modificar la lista.") }}</div>
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label small fw-semibold" for="email-subject">{{ _("Asunto") }}</label>
+          <input type="text" class="form-control form-control-sm" id="email-subject" x-model="subject" placeholder="{{ _('Asunto del correo') }}" :disabled="loading">
+        </div>
+
+        <div class="mb-3">
+          <label class="form-label small fw-semibold" for="email-body">{{ _("Mensaje / Contenido") }}</label>
+          <textarea class="form-control form-control-sm" id="email-body" x-model="body" rows="6" placeholder="{{ _('Redacte el mensaje...') }}" :disabled="loading"></textarea>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal" :disabled="loading">{{ _("Cancelar") }}</button>
+        <button type="button" class="btn btn-sm btn-primary" @click="sendEmail()" :disabled="loading">
+          <span x-show="loading" class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+          <i x-show="!loading" class="bi bi-send me-1"></i>
+          {{ _("Enviar Correo") }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+{% endmacro %}
+
 {# ─── Primary document shortcuts ─────────────────────────────── #}
 {% macro document_create_actions(document_type, document) %}
 {% set actions = get_document_create_actions(document_type, document.id) %}

--- a/tests/test_transaction_emails.py
+++ b/tests/test_transaction_emails.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pruebas para notificaciones por correo electrónico en transacciones operativas."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from cacao_accounting import create_app
+from cacao_accounting.database import (
+    AuditTrail,
+    CacaoConfig,
+    CompanyParty,
+    EmailQueue,
+    Entity,
+    Modules,
+    Party,
+    PurchaseOrder,
+    User,
+    database,
+)
+from cacao_accounting.messaging.email import (
+    EmailError,
+    can_send_transaction_emails,
+    get_document_default_recipient_email,
+    get_smtp_setting,
+    retry_email_queue_item,
+    set_smtp_setting,
+)
+
+
+@pytest.fixture()
+def app_ctx():
+    """Create an isolated app with database in-memory for transaction email tests."""
+    app = create_app(
+        {
+            "TESTING": True,
+            "SECRET_KEY": "transaction_email_test_secret",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+            "WTF_CSRF_ENABLED": False,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "MODO_ESCRITORIO": False,
+        }
+    )
+    with app.app_context():
+        database.create_all()
+
+        from cacao_accounting.auth.helpers import ph
+
+        user = User(
+            user="admin_email_user",
+            name="Admin Email User",
+            password=ph.hash("secretpassword").encode("utf-8"),
+            classification="admin",
+            active=True,
+        )
+        database.session.add(user)
+
+        entity = Entity(
+            code="EMP1", company_name="Compañía Email Test", name="Compañía Email Test", tax_id="123456789", enabled=True
+        )
+        database.session.add(entity)
+
+        supplier = Party(
+            code="SUPP001",
+            name="Proveedor Test SA",
+            primary_email="proveedor@test.com",
+            is_active=True,
+        )
+        database.session.add(supplier)
+        database.session.flush()
+
+        cp = CompanyParty(company=entity.code, party_id=supplier.id, is_active=True)
+        database.session.add(cp)
+
+        po = PurchaseOrder(
+            id="PO-EMAIL-001",
+            document_no="PO-2026-0001",
+            company="EMP1",
+            supplier_id=supplier.id,
+            supplier_name="Proveedor Test SA",
+            docstatus=0,
+            status="draft",
+        )
+        database.session.add(po)
+
+        mod = Modules(module="purchases", default=False, enabled=True)
+        database.session.add(mod)
+        mod_admin = Modules(module="admin", default=True, enabled=True)
+        database.session.add(mod_admin)
+
+        database.session.commit()
+        yield app
+        database.session.remove()
+        database.drop_all()
+
+
+def test_can_send_transaction_emails_desktop_mode(app_ctx):
+    """Verify transaction email logic returns False in desktop mode."""
+    with app_ctx.app_context():
+        app_ctx.config["MODO_ESCRITORIO"] = True
+        try:
+            assert can_send_transaction_emails() is False
+        finally:
+            app_ctx.config["MODO_ESCRITORIO"] = False
+
+
+def test_can_send_transaction_emails_unconfigured(app_ctx):
+    """Verify transaction email logic returns False if SMTP is unconfigured."""
+    with app_ctx.app_context():
+        database.session.execute(database.delete(CacaoConfig))
+        database.session.commit()
+        assert can_send_transaction_emails() is False
+
+
+def test_can_send_transaction_emails_enabled_and_disabled(app_ctx):
+    """Verify transaction email logic respects SMTP config and admin toggle."""
+    with app_ctx.app_context():
+        database.session.execute(database.delete(CacaoConfig))
+        set_smtp_setting("smtp_server", "smtp.test.com")
+        set_smtp_setting("smtp_from_email", "noreply@test.com")
+        set_smtp_setting("disable_transaction_emails", "false")
+        database.session.commit()
+
+        assert can_send_transaction_emails() is True
+
+        set_smtp_setting("disable_transaction_emails", "true")
+        database.session.commit()
+
+        assert can_send_transaction_emails() is False
+
+
+def test_get_document_default_recipient_email(app_ctx):
+    """Verify supplier email resolution for purchase documents."""
+    with app_ctx.app_context():
+        email = get_document_default_recipient_email("purchase_order", "PO-EMAIL-001")
+        assert email == "proveedor@test.com"
+
+        email_nonexistent = get_document_default_recipient_email("purchase_order", "PO-NONEXISTENT")
+        assert email_nonexistent == ""
+
+
+def test_admin_toggle_transaction_emails_view(app_ctx):
+    """Verify admin email settings view saves transaction email disable toggle."""
+    with app_ctx.test_client() as client:
+        client.post("/login", data={"usuario": "admin_email_user", "acceso": "secretpassword"})
+
+        response = client.post(
+            "/settings/email",
+            data={
+                "smtp_server": "smtp.test.com",
+                "smtp_port": "587",
+                "smtp_from_email": "noreply@test.com",
+                "disable_transaction_emails": "on",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+
+        with app_ctx.app_context():
+            assert get_smtp_setting("disable_transaction_emails") == "true"
+            assert can_send_transaction_emails() is False
+
+
+@mock.patch("cacao_accounting.messaging.email.send_email")
+def test_api_document_email_info_and_send_success(mock_send_email, app_ctx):
+    """Verify GET email-info and POST email dispatch with queue & audit log on success."""
+    with app_ctx.app_context():
+        set_smtp_setting("smtp_server", "smtp.test.com")
+        set_smtp_setting("smtp_from_email", "noreply@test.com")
+        set_smtp_setting("disable_transaction_emails", "false")
+        database.session.commit()
+
+    with app_ctx.test_client() as client:
+        client.post("/login", data={"usuario": "admin_email_user", "acceso": "secretpassword"})
+
+        # Test email-info
+        resp_info = client.get("/api/documents/purchase_order/PO-EMAIL-001/email-info")
+        assert resp_info.status_code == 200
+        data_info = resp_info.get_json()
+        assert data_info["enabled"] is True
+        assert data_info["default_recipient"] == "proveedor@test.com"
+
+        # Test send email success
+        resp_send = client.post(
+            "/api/documents/purchase_order/PO-EMAIL-001/email",
+            json={
+                "recipients": "proveedor@test.com, adicional@test.com",
+                "subject": "Prueba de Orden de Compra",
+                "body": "Cuerpo del mensaje de prueba",
+            },
+        )
+        assert resp_send.status_code == 200
+        data_send = resp_send.get_json()
+        assert data_send["success"] is True
+        assert data_send["sent_count"] == 2
+
+        assert mock_send_email.call_count == 2
+
+        # Verify AuditTrail record was created
+        with app_ctx.app_context():
+            logs = (
+                database.session.execute(
+                    database.select(AuditTrail).where(
+                        AuditTrail.document_id == "PO-EMAIL-001",
+                        AuditTrail.action == "email_sent",
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(logs) == 1
+            assert "correo enviado exitosamente a proveedor@test.com, adicional@test.com" in logs[0].comment
+
+            queue_items = (
+                database.session.execute(database.select(EmailQueue).where(EmailQueue.document_id == "PO-EMAIL-001"))
+                .scalars()
+                .all()
+            )
+            assert len(queue_items) == 2
+            assert all(item.status == "sent" for item in queue_items)
+
+
+@mock.patch("cacao_accounting.messaging.email.send_email", side_effect=EmailError("Fallo de conexión SMTP"))
+def test_api_document_email_send_failure_queue_recorded(mock_send_email, app_ctx):
+    """Verify that email send failure logs failed status in EmailQueue and creates NO audit log."""
+    with app_ctx.app_context():
+        set_smtp_setting("smtp_server", "smtp.test.com")
+        set_smtp_setting("smtp_from_email", "noreply@test.com")
+        set_smtp_setting("disable_transaction_emails", "false")
+        database.session.commit()
+
+    with app_ctx.test_client() as client:
+        client.post("/login", data={"usuario": "admin_email_user", "acceso": "secretpassword"})
+
+        resp = client.post(
+            "/api/documents/purchase_order/PO-EMAIL-001/email",
+            json={
+                "recipients": "proveedor@test.com",
+                "subject": "Asunto Test",
+                "body": "Cuerpo Test",
+            },
+        )
+        assert resp.status_code == 500
+        data = resp.get_json()
+        assert "Fallo de conexión SMTP" in data["error"]
+
+        with app_ctx.app_context():
+            logs = (
+                database.session.execute(
+                    database.select(AuditTrail).where(
+                        AuditTrail.document_id == "PO-EMAIL-001",
+                        AuditTrail.action == "email_sent",
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(logs) == 0
+
+            queue_items = (
+                database.session.execute(database.select(EmailQueue).where(EmailQueue.document_id == "PO-EMAIL-001"))
+                .scalars()
+                .all()
+            )
+            assert len(queue_items) == 1
+            assert queue_items[0].status == "failed"
+            assert "Fallo de conexión SMTP" in queue_items[0].error_message
+
+
+def test_admin_email_log_view_and_retry(app_ctx):
+    """Verify admin email log view and retry action for failed queue items."""
+    with app_ctx.app_context():
+        set_smtp_setting("smtp_server", "smtp.test.com")
+        set_smtp_setting("smtp_from_email", "noreply@test.com")
+
+        item = EmailQueue(
+            document_type="purchase_order",
+            document_id="PO-EMAIL-001",
+            recipient="retry@test.com",
+            subject="Asunto Reintento",
+            body="Cuerpo Reintento",
+            status="failed",
+            error_message="Error previo",
+            attempts=1,
+        )
+        database.session.add(item)
+        database.session.commit()
+        queue_id = item.id
+
+    with app_ctx.test_client() as client:
+        client.post("/login", data={"usuario": "admin_email_user", "acceso": "secretpassword"})
+
+        resp_log = client.get("/settings/email-log")
+        assert resp_log.status_code == 200
+        assert b"Bit" in resp_log.data and b"cora de Correos" in resp_log.data
+        assert b"retry@test.com" in resp_log.data
+
+        with mock.patch("cacao_accounting.messaging.email.send_email") as mock_send:
+            resp_retry = client.post(
+                f"/settings/email-log/{queue_id}/retry",
+                follow_redirects=True,
+            )
+            assert resp_retry.status_code == 200
+            mock_send.assert_called_once_with(
+                to_email="retry@test.com",
+                subject="Asunto Reintento",
+                body="Cuerpo Reintento",
+                is_html=False,
+            )
+
+        with app_ctx.app_context():
+            updated = database.session.get(EmailQueue, queue_id)
+            assert updated.status == "sent"
+            assert updated.attempts == 2
+            assert updated.error_message is None


### PR DESCRIPTION
Add operational transaction email notifications for Cloud mode, featuring recipient email auto-discovery, background AJAX email sending, email queue logging, admin global disable toggle, admin email queue/log view with retry option, and audit trail updates upon successful email delivery.

---
*PR created automatically by Jules for task [10834919350437838079](https://jules.google.com/task/10834919350437838079) started by @williamjmorenor*