### PR TITLE
Fix mypy schema typing and fiscal year closing exchange rate handling

### DIFF
--- a/cacao_accounting/contabilidad/posting.py
+++ b/cacao_accounting/contabilidad/posting.py
@@ -225,6 +225,7 @@ def _document_contexts(document: Any, ledger_code: str | Sequence[str] | None = 
         # conversión a libros con moneda distinta.
         transaction_currency = document_base_currency
     contexts: list[LedgerContext] = []
+    is_fy_closing = bool(getattr(document, "is_fiscal_year_closing", False))
     for book in _active_books(company, ledger_code):
         book_currency = getattr(book, "currency", None)
         company_currency = book_currency or document_base_currency or default_company_currency
@@ -234,6 +235,7 @@ def _document_contexts(document: Any, ledger_code: str | Sequence[str] | None = 
             document_base_currency=document_base_currency,
             document_exchange_rate=document_exchange_rate,
             posting_date=posting_date,
+            is_fiscal_year_closing=is_fy_closing,
         )
         contexts.append(
             LedgerContext(
@@ -263,8 +265,11 @@ def _ledger_exchange_rate(
     document_base_currency: str | None,
     document_exchange_rate: Any,
     posting_date: Any,
+    is_fiscal_year_closing: bool = False,
 ) -> Decimal | None:
     """Resolve the historical conversion rate independently for each book."""
+    if is_fiscal_year_closing:
+        return Decimal("1")
     if not transaction_currency or not ledger_currency or transaction_currency == ledger_currency:
         return None
     if ledger_currency == document_base_currency and document_exchange_rate is not None:
@@ -476,6 +481,7 @@ def _resolve_gl_amounts(
     exchange_rate = params.exchange_rate if params.exchange_rate is not None else context.exchange_rate
     requires_conversion = (
         not params.is_reversal
+        and not params.is_fiscal_year_closing
         and context.transaction_currency
         and context.company_currency
         and context.transaction_currency != context.company_currency

--- a/cacao_accounting/query_tools/schemas/accounting.py
+++ b/cacao_accounting/query_tools/schemas/accounting.py
@@ -1,6 +1,8 @@
 """Esquemas de validación para los endpoints del módulo de contabilidad."""
 
-ACCOUNTING_PERIODS_PARAMS = {
+from typing import Any
+
+ACCOUNTING_PERIODS_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string", "description": "Código de la compañía"},
@@ -15,7 +17,7 @@ ACCOUNTING_PERIODS_PARAMS = {
     "required": ["company_id"],
 }
 
-ACCOUNTS_SEARCH_PARAMS = {
+ACCOUNTS_SEARCH_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},
@@ -31,7 +33,7 @@ ACCOUNTS_SEARCH_PARAMS = {
     "required": ["company_id"],
 }
 
-TRIAL_BALANCE_PARAMS = {
+TRIAL_BALANCE_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},
@@ -44,7 +46,7 @@ TRIAL_BALANCE_PARAMS = {
     "required": ["company_id", "ledger_id", "date_from", "date_to"],
 }
 
-GENERAL_LEDGER_PARAMS = {
+GENERAL_LEDGER_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},

--- a/cacao_accounting/query_tools/schemas/audit_trail.py
+++ b/cacao_accounting/query_tools/schemas/audit_trail.py
@@ -1,6 +1,8 @@
 """Esquemas de validación para los endpoints del módulo de pista de auditoría."""
 
-DOCUMENT_TIMELINE_PARAMS = {
+from typing import Any
+
+DOCUMENT_TIMELINE_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},

--- a/cacao_accounting/query_tools/schemas/banking.py
+++ b/cacao_accounting/query_tools/schemas/banking.py
@@ -1,6 +1,8 @@
 """Esquemas de validación para los endpoints del módulo de banca."""
 
-BANKING_ACCOUNTS_PARAMS = {
+from typing import Any
+
+BANKING_ACCOUNTS_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},
@@ -10,7 +12,7 @@ BANKING_ACCOUNTS_PARAMS = {
     "required": ["company_id"],
 }
 
-BANKING_TRANSACTIONS_PARAMS = {
+BANKING_TRANSACTIONS_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},

--- a/cacao_accounting/query_tools/schemas/common.py
+++ b/cacao_accounting/query_tools/schemas/common.py
@@ -1,6 +1,8 @@
 """Esquemas de validación comunes compartidos entre módulos."""
 
-PAGINATION_PARAMS = {
+from typing import Any
+
+PAGINATION_PARAMS: dict[str, Any] = {
     "page": {
         "type": "integer",
         "description": "Número de página (empieza en 1)",
@@ -15,7 +17,7 @@ PAGINATION_PARAMS = {
     },
 }
 
-DATE_FILTERS = {
+DATE_FILTERS: dict[str, Any] = {
     "date_from": {
         "type": "string",
         "format": "date",
@@ -28,7 +30,7 @@ DATE_FILTERS = {
     },
 }
 
-PAGINATED_RESPONSE = {
+PAGINATED_RESPONSE: dict[str, Any] = {
     "type": "object",
     "properties": {
         "page": {"type": "integer"},
@@ -40,7 +42,7 @@ PAGINATED_RESPONSE = {
     },
 }
 
-ERROR_RESPONSE = {
+ERROR_RESPONSE: dict[str, Any] = {
     "type": "object",
     "properties": {
         "error": {
@@ -54,7 +56,7 @@ ERROR_RESPONSE = {
     },
 }
 
-COMPANY_PARAM = {
+COMPANY_PARAM: dict[str, Any] = {
     "company_id": {
         "type": "string",
         "description": "Código de la compañía",

--- a/cacao_accounting/query_tools/schemas/companies.py
+++ b/cacao_accounting/query_tools/schemas/companies.py
@@ -1,6 +1,8 @@
 """Esquemas de validación para los endpoints del módulo de compañías."""
 
-COMPANIES_LIST_PARAMS = {
+from typing import Any
+
+COMPANIES_LIST_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "page": {"type": "integer", "default": 1},
@@ -8,7 +10,7 @@ COMPANIES_LIST_PARAMS = {
     },
 }
 
-COMPANIES_LIST_RESPONSE = {
+COMPANIES_LIST_RESPONSE: dict[str, Any] = {
     "type": "object",
     "properties": {
         "page": {"type": "integer"},

--- a/cacao_accounting/query_tools/schemas/documents.py
+++ b/cacao_accounting/query_tools/schemas/documents.py
@@ -1,6 +1,8 @@
 """Esquemas de validación para los endpoints del módulo de documentos."""
 
-DOCUMENTS_FLOW_PARAMS = {
+from typing import Any
+
+DOCUMENTS_FLOW_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},

--- a/cacao_accounting/query_tools/schemas/payables.py
+++ b/cacao_accounting/query_tools/schemas/payables.py
@@ -1,6 +1,8 @@
 """Esquemas de validación para los endpoints del módulo de cuentas por pagar."""
 
-PAYABLES_AGING_PARAMS = {
+from typing import Any
+
+PAYABLES_AGING_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},
@@ -12,7 +14,7 @@ PAYABLES_AGING_PARAMS = {
     "required": ["company_id", "as_of_date"],
 }
 
-PAYABLES_OPEN_DOCUMENTS_PARAMS = {
+PAYABLES_OPEN_DOCUMENTS_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},

--- a/cacao_accounting/query_tools/schemas/receivables.py
+++ b/cacao_accounting/query_tools/schemas/receivables.py
@@ -1,6 +1,8 @@
 """Esquemas de validación para los endpoints del módulo de cuentas por cobrar."""
 
-RECEIVABLES_AGING_PARAMS = {
+from typing import Any
+
+RECEIVABLES_AGING_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},
@@ -12,7 +14,7 @@ RECEIVABLES_AGING_PARAMS = {
     "required": ["company_id", "as_of_date"],
 }
 
-RECEIVABLES_OPEN_DOCUMENTS_PARAMS = {
+RECEIVABLES_OPEN_DOCUMENTS_PARAMS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "company_id": {"type": "string"},

--- a/cacao_accounting/query_tools/tests/test_schemas.py
+++ b/cacao_accounting/query_tools/tests/test_schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 import pytest
 
 from cacao_accounting.query_tools.schemas.accounting import (
@@ -37,14 +38,14 @@ from cacao_accounting.query_tools.schemas.receivables import (
 )
 
 
-def _assert_object_schema(schema: dict, required: set[str], properties: set[str]) -> None:
+def _assert_object_schema(schema: dict[str, Any], required: set[str], properties: set[str]) -> None:
     """Comprueba el contrato común de un esquema de parámetros JSON."""
     assert schema["type"] == "object"
     assert set(schema.get("required", [])) == required
     assert set(schema["properties"]) == properties
 
 
-def _assert_pagination_properties(schema: dict) -> None:
+def _assert_pagination_properties(schema: dict[str, Any]) -> None:
     """Comprueba los límites públicos de paginación."""
     assert schema["properties"]["page"] == {"type": "integer", "default": 1}
     assert schema["properties"]["page_size"] == {"type": "integer", "default": 100, "maximum": 500}
@@ -75,7 +76,9 @@ def _assert_pagination_properties(schema: dict) -> None:
         ),
     ],
 )
-def test_receivables_and_payables_schemas_have_expected_contract(schema, required, properties):
+def test_receivables_and_payables_schemas_have_expected_contract(
+    schema: dict[str, Any], required: set[str], properties: set[str]
+) -> None:
     """Verifica filtros, requisitos y paginación de AR y AP."""
     _assert_object_schema(schema, required, properties)
     _assert_pagination_properties(schema)


### PR DESCRIPTION
Annotate query tools schema constants and test parameters with dict[str, Any] to resolve mypy indexing errors. Update posting engine to bypass exchange rate conversion when posting fiscal year closing entries expressed in functional book currencies.

---
*PR created automatically by Jules for task [3747173911800136471](https://jules.google.com/task/3747173911800136471) started by @williamjmorenor*