### PR TITLE
Add cloud-only file attachment and item product image support

### DIFF
--- a/SESSIONS.md
+++ b/SESSIONS.md
@@ -1,5 +1,30 @@
 # SESSIONS — Bitácora de Decisiones de Diseño
 
+## 2026-08-23 — Correcciones de code review en adjuntos e imágenes (#717)
+
+### Petición
+
+Aplicar las mejoras requeridas por los comentarios de code review de los PR
+abiertos, sin incorporar reversiones ni riesgos antes de integrar a `main`.
+
+### Implementado
+
+- Se añadió autorización por referencia, documento, compañía y módulo para
+  listar, subir, descargar y eliminar adjuntos.
+- Las mutaciones de imágenes de inventario requieren permiso de edición.
+- La validación de imágenes exige extensión, MIME y firma binaria compatibles.
+- El reemplazo de una imagen valida y persiste la nueva antes de eliminar la
+  anterior, preservando la imagen existente ante fallos.
+- Se añadieron regresiones para autorización del flujo API, firmas inválidas y
+  preservación de imágenes.
+
+### Validación
+
+- `tests/test_attachment_service.py`: **6 passed**.
+- Batería focal ampliada (`tests/test_attachment_service.py` y
+  `tests/test_01vistas.py`): **7 passed**.
+- Ruff, formato Ruff y `git diff --check`: correctos.
+
 ## 2026-08-23 — Diagnóstico de fallo Desktop en portal
 
 ### Hallazgo

--- a/cacao_accounting/__init__.py
+++ b/cacao_accounting/__init__.py
@@ -291,6 +291,9 @@ def actualiza_variables_globales_jinja(app: Flask | None = None) -> None:
             from cacao_accounting.document_flow.status import calculate_document_status
 
             app.jinja_env.globals.update(document_status_info=calculate_document_status)
+            from cacao_accounting.attachment_service import list_attachments
+
+            app.jinja_env.globals.update(get_document_attachments=list_attachments)
             # now available globally in templates
             app.jinja_env.globals.update(now=datetime.now)
             app.jinja_env.globals.update(getattr=getattr)

--- a/cacao_accounting/api/__init__.py
+++ b/cacao_accounting/api/__init__.py
@@ -27,7 +27,7 @@ from cacao_accounting.attachment_service import (
 )
 from jwt import decode
 from jwt.exceptions import PyJWTError
-from werkzeug.exceptions import Forbidden
+from werkzeug.exceptions import Forbidden, HTTPException
 
 # ---------------------------------------------------------------------------------------
 # Recursos locales
@@ -54,7 +54,9 @@ from cacao_accounting.collaboration_service import (
     open_task_count,
     update_task_status,
 )
-from cacao_accounting.database import Entity, StockBin, database
+from cacao_accounting.database import Entity, FileAttachment, Party, StockBin, database
+from cacao_accounting.auth.permisos import Permisos
+from cacao_accounting.database.helpers import obtener_id_modulo_por_nombre
 from cacao_accounting.decorators import exige_acceso_compania, exige_acceso_compania_cualquiera
 from cacao_accounting.api.dashboard import user_can_access_company
 from cacao_accounting.document_flow.registry import DOCUMENT_TYPES, DocumentType, normalize_doctype
@@ -152,6 +154,67 @@ def _require_document_send_access(document_type: str, document_id: str) -> Any:
         else:
             exige_acceso_compania(module, getattr(document, "company", None), "autorizar")
     return document
+
+
+_ATTACHMENT_MASTER_MODULES = {
+    "customer": "sales",
+    "supplier": "purchases",
+}
+
+
+def _require_attachment_reference_access(reference_type: str, reference_id: str, action: str = "consultar") -> None:
+    """Authorize access to an attachment reference before touching its file."""
+    if getattr(current_user, "classification", None) == "admin":
+        return
+    normalized_type = normalize_doctype(reference_type)
+    normalized_type = {"import_landed_cost": "landed_cost"}.get(normalized_type, normalized_type)
+
+    master_module = _ATTACHMENT_MASTER_MODULES.get(normalized_type)
+    if master_module:
+        if not database.session.get(Party, reference_id):
+            abort(404)
+        module_id = obtener_id_modulo_por_nombre(master_module)
+        permisos = Permisos(modulo=module_id, usuario=current_user.id)
+        permission = {"consultar": "consultar", "editar": "editar"}[action]
+        if not getattr(permisos, permission, False):
+            abort(403)
+        return
+
+    try:
+        document = get_document(normalized_type, reference_id)
+    except (KeyError, ValueError):
+        abort(400)
+    if not document:
+        abort(404)
+    module = _module_for_document_type(normalized_type) or {"landed_cost": "purchases"}.get(normalized_type)
+    if not module:
+        abort(400)
+    exige_acceso_compania(module, getattr(document, "company", None), action)
+
+
+def _require_attachment_file_access(file_id: str, action: str = "consultar") -> None:
+    """Authorize at least one reference linked to an attachment file."""
+    links = database.session.execute(database.select(FileAttachment).where(FileAttachment.file_id == file_id)).scalars().all()
+    if not links:
+        abort(404)
+    for link in links:
+        try:
+            _require_attachment_reference_access(link.reference_type, link.reference_id, action)
+            return
+        except HTTPException as exc:
+            if exc.code != 403:
+                raise
+    abort(403)
+
+
+def _require_inventory_image_edit_access() -> None:
+    """Require inventory write permission for product-image mutations."""
+    if getattr(current_user, "classification", None) == "admin":
+        return
+    module_id = obtener_id_modulo_por_nombre("inventory")
+    permisos = Permisos(modulo=module_id, usuario=current_user.id)
+    if not permisos.editar:
+        abort(403)
 
 
 def token_requerido(f):  # pragma: no cover
@@ -524,6 +587,7 @@ def _date_filter(name: str):
 @login_required
 def api_upload_attachment(reference_type: str, reference_id: str):
     """Upload a file attachment for a document or master record (Cloud mode only)."""
+    _require_attachment_reference_access(reference_type, reference_id, "editar")
     file = request.files.get("file") or request.files.get("attachment")
     remarks = request.form.get("remarks") or request.form.get("description")
     try:
@@ -557,6 +621,7 @@ def api_upload_attachment(reference_type: str, reference_id: str):
 @login_required
 def api_list_attachments(reference_type: str, reference_id: str):
     """List attachments for a document or master record."""
+    _require_attachment_reference_access(reference_type, reference_id)
     attachments = list_attachments(reference_type, reference_id)
     return jsonify(attachments)
 
@@ -565,6 +630,7 @@ def api_list_attachments(reference_type: str, reference_id: str):
 @login_required
 def api_download_attachment(file_id: str):
     """Download/serve an attached file."""
+    _require_attachment_file_access(file_id)
     try:
         file_rec, path = get_attachment_file(file_id)
         return send_file(
@@ -584,6 +650,7 @@ def api_delete_attachment(file_id: str):
     payload = request.get_json(silent=True) or request.form.to_dict()
     ref_type = payload.get("reference_type") or request.args.get("reference_type") or ""
     ref_id = payload.get("reference_id") or request.args.get("reference_id") or ""
+    _require_attachment_reference_access(ref_type, ref_id, "editar")
     try:
         delete_attachment(file_id, ref_type, ref_id, user_id=str(current_user.id))
     except AttachmentError as exc:
@@ -609,6 +676,7 @@ def api_delete_attachment(file_id: str):
 @login_required
 def api_upload_item_image(item_id: str):
     """Upload product image for an item (Cloud mode only)."""
+    _require_inventory_image_edit_access()
     file = request.files.get("file") or request.files.get("product_image") or request.files.get("image")
     try:
         result = upload_item_image(item_id, file, user_id=str(current_user.id))
@@ -648,6 +716,7 @@ def api_get_item_image(item_id: str):
 @login_required
 def api_delete_item_image(item_id: str):
     """Delete product image of an inventory item (Cloud mode only)."""
+    _require_inventory_image_edit_access()
     try:
         delete_item_image(item_id, user_id=str(current_user.id))
     except AttachmentError as exc:

--- a/cacao_accounting/api/__init__.py
+++ b/cacao_accounting/api/__init__.py
@@ -13,8 +13,18 @@ from urllib.parse import urlparse
 # ---------------------------------------------------------------------------------------
 # Librerias de terceros
 # ---------------------------------------------------------------------------------------
-from flask import Blueprint, abort, current_app, jsonify, redirect, render_template, request, url_for
+from flask import Blueprint, abort, current_app, flash, jsonify, redirect, render_template, request, send_file, url_for
 from flask_login import current_user, login_required
+from cacao_accounting.attachment_service import (
+    AttachmentError,
+    delete_attachment,
+    delete_item_image,
+    get_attachment_file,
+    get_item_image_file,
+    list_attachments,
+    upload_attachment,
+    upload_item_image,
+)
 from jwt import decode
 from jwt.exceptions import PyJWTError
 from werkzeug.exceptions import Forbidden
@@ -508,6 +518,155 @@ def _date_filter(name: str):
         return date.fromisoformat(value)
     except ValueError:
         abort(400)
+
+
+@api.route("/api/attachments/<reference_type>/<reference_id>/upload", methods=["POST"])
+@login_required
+def api_upload_attachment(reference_type: str, reference_id: str):
+    """Upload a file attachment for a document or master record (Cloud mode only)."""
+    file = request.files.get("file") or request.files.get("attachment")
+    remarks = request.form.get("remarks") or request.form.get("description")
+    try:
+        result = upload_attachment(
+            reference_type,
+            reference_id,
+            file,
+            user_id=str(current_user.id),
+            remarks=remarks,
+        )
+    except AttachmentError as exc:
+        if request.form and request.referrer:
+            flash(str(exc), "danger")
+            parsed = urlparse(request.referrer)
+            if parsed.netloc == "" or parsed.netloc == request.host:
+                return redirect(request.referrer)
+            return redirect(url_for("cacao_app.pagina_inicio"))
+        return jsonify({"error": str(exc)}), exc.status_code
+
+    if request.form and request.referrer:
+        flash(_("Archivo adjuntado exitosamente."), "success")
+        parsed = urlparse(request.referrer)
+        if parsed.netloc == "" or parsed.netloc == request.host:
+            return redirect(request.referrer)
+        return redirect(url_for("cacao_app.pagina_inicio"))
+
+    return jsonify(result), 201
+
+
+@api.route("/api/attachments/<reference_type>/<reference_id>", methods=["GET"])
+@login_required
+def api_list_attachments(reference_type: str, reference_id: str):
+    """List attachments for a document or master record."""
+    attachments = list_attachments(reference_type, reference_id)
+    return jsonify(attachments)
+
+
+@api.route("/attachments/download/<file_id>", methods=["GET"])
+@login_required
+def api_download_attachment(file_id: str):
+    """Download/serve an attached file."""
+    try:
+        file_rec, path = get_attachment_file(file_id)
+        return send_file(
+            path,
+            download_name=file_rec.file_name,
+            mimetype=file_rec.mime_type or "application/octet-stream",
+            as_attachment=True,
+        )
+    except AttachmentError as exc:
+        abort(exc.status_code)
+
+
+@api.route("/api/attachments/<file_id>/delete", methods=["POST"])
+@login_required
+def api_delete_attachment(file_id: str):
+    """Delete an attachment (Cloud mode only)."""
+    payload = request.get_json(silent=True) or request.form.to_dict()
+    ref_type = payload.get("reference_type") or request.args.get("reference_type") or ""
+    ref_id = payload.get("reference_id") or request.args.get("reference_id") or ""
+    try:
+        delete_attachment(file_id, ref_type, ref_id, user_id=str(current_user.id))
+    except AttachmentError as exc:
+        if request.form and request.referrer:
+            flash(str(exc), "danger")
+            parsed = urlparse(request.referrer)
+            if parsed.netloc == "" or parsed.netloc == request.host:
+                return redirect(request.referrer)
+            return redirect(url_for("cacao_app.pagina_inicio"))
+        return jsonify({"error": str(exc)}), exc.status_code
+
+    if request.form and request.referrer:
+        flash(_("Adjunto eliminado."), "info")
+        parsed = urlparse(request.referrer)
+        if parsed.netloc == "" or parsed.netloc == request.host:
+            return redirect(request.referrer)
+        return redirect(url_for("cacao_app.pagina_inicio"))
+
+    return jsonify({"success": True})
+
+
+@api.route("/api/inventory/items/<item_id>/image", methods=["POST"])
+@login_required
+def api_upload_item_image(item_id: str):
+    """Upload product image for an item (Cloud mode only)."""
+    file = request.files.get("file") or request.files.get("product_image") or request.files.get("image")
+    try:
+        result = upload_item_image(item_id, file, user_id=str(current_user.id))
+    except AttachmentError as exc:
+        if request.form and request.referrer:
+            flash(str(exc), "danger")
+            parsed = urlparse(request.referrer)
+            if parsed.netloc == "" or parsed.netloc == request.host:
+                return redirect(request.referrer)
+            return redirect(url_for("cacao_app.pagina_inicio"))
+        return jsonify({"error": str(exc)}), exc.status_code
+
+    if request.form and request.referrer:
+        flash(_("Imagen del producto actualizada."), "success")
+        parsed = urlparse(request.referrer)
+        if parsed.netloc == "" or parsed.netloc == request.host:
+            return redirect(request.referrer)
+        return redirect(url_for("cacao_app.pagina_inicio"))
+
+    return jsonify(result), 200
+
+
+@api.route("/api/inventory/items/<item_id>/image", methods=["GET"])
+@login_required
+def api_get_item_image(item_id: str):
+    """Serve product image of an inventory item."""
+    file_rec, path = get_item_image_file(item_id)
+    if not path or not file_rec:
+        abort(404)
+    return send_file(
+        path,
+        mimetype=file_rec.mime_type or "image/png",
+    )
+
+
+@api.route("/api/inventory/items/<item_id>/image/delete", methods=["POST"])
+@login_required
+def api_delete_item_image(item_id: str):
+    """Delete product image of an inventory item (Cloud mode only)."""
+    try:
+        delete_item_image(item_id, user_id=str(current_user.id))
+    except AttachmentError as exc:
+        if request.form and request.referrer:
+            flash(str(exc), "danger")
+            parsed = urlparse(request.referrer)
+            if parsed.netloc == "" or parsed.netloc == request.host:
+                return redirect(request.referrer)
+            return redirect(url_for("cacao_app.pagina_inicio"))
+        return jsonify({"error": str(exc)}), exc.status_code
+
+    if request.form and request.referrer:
+        flash(_("Imagen eliminada."), "info")
+        parsed = urlparse(request.referrer)
+        if parsed.netloc == "" or parsed.netloc == request.host:
+            return redirect(request.referrer)
+        return redirect(url_for("cacao_app.pagina_inicio"))
+
+    return jsonify({"success": True})
 
 
 @api.route("/api/buying/purchase-order/<order_id>/items")

--- a/cacao_accounting/attachment_service.py
+++ b/cacao_accounting/attachment_service.py
@@ -218,10 +218,24 @@ def upload_item_image(item_id: str, file_storage: Any, user_id: str | None = Non
     ext = os.path.splitext(file_storage.filename)[1].lower()
     content_type = getattr(file_storage, "content_type", "") or ""
 
-    if ext not in ALLOWED_IMAGE_EXTENSIONS and not content_type.startswith("image/"):
+    if ext not in ALLOWED_IMAGE_EXTENSIONS or not content_type.startswith("image/"):
         raise AttachmentError("Formato de imagen no permitido. Use PNG, JPG, WEBP, GIF o SVG.", 400)
 
-    delete_item_image(item.code, user_id=user_id, ignore_missing=True)
+    file_storage.seek(0)
+    header = file_storage.read(4096)
+    file_storage.seek(0)
+    if not _has_valid_image_signature(header, ext):
+        raise AttachmentError("El contenido no corresponde a una imagen válida.", 400)
+
+    old_attachments = (
+        database.session.execute(
+            database.select(FileAttachment)
+            .where(FileAttachment.reference_type == "item_image")
+            .where(FileAttachment.reference_id == item.code)
+        )
+        .scalars()
+        .all()
+    )
 
     upload_result = upload_attachment(
         reference_type="item_image",
@@ -235,11 +249,29 @@ def upload_item_image(item_id: str, file_storage: Any, user_id: str | None = Non
     item.image_path = path
     database.session.commit()
 
+    for old_attachment in old_attachments:
+        delete_attachment(old_attachment.file_id, "item_image", item.code, user_id=user_id)
+
     return {
         "item_id": item.code,
         "image_path": path,
         "file_id": file_rec.id,
     }
+
+
+def _has_valid_image_signature(header: bytes, extension: str) -> bool:
+    """Check the file signature instead of trusting multipart metadata alone."""
+    if extension == ".png":
+        return header.startswith(b"\x89PNG\r\n\x1a\n")
+    if extension in {".jpg", ".jpeg"}:
+        return header.startswith(b"\xff\xd8\xff")
+    if extension == ".gif":
+        return header.startswith((b"GIF87a", b"GIF89a"))
+    if extension == ".webp":
+        return len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP"
+    if extension == ".svg":
+        return b"<svg" in header.lower()
+    return False
 
 
 def delete_item_image(item_id: str, user_id: str | None = None, ignore_missing: bool = False) -> bool:

--- a/cacao_accounting/attachment_service.py
+++ b/cacao_accounting/attachment_service.py
@@ -1,0 +1,299 @@
+"""Cloud-only file attachment and item image service."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Any
+
+from flask import current_app
+from werkzeug.utils import secure_filename
+
+from cacao_accounting.database import File, FileAttachment, Item, database
+from cacao_accounting.runtime_mode import is_desktop_mode
+
+MAX_FILE_SIZE = 16 * 1024 * 1024  # 16 MB
+ALLOWED_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".svg"}
+
+
+class AttachmentError(ValueError):
+    """Controlled validation error for attachment operations."""
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        """Initialize attachment error with message and HTTP status code."""
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _ensure_cloud_mode() -> None:
+    if is_desktop_mode():
+        raise AttachmentError("La subida de archivos no está disponible en modo escritorio.", 403)
+
+
+def _get_upload_folder() -> str:
+    if current_app:
+        folder = current_app.config.get("UPLOAD_FOLDER")
+        if not folder:
+            folder = os.path.join(current_app.instance_path, "uploads")
+    else:
+        folder = os.path.join(os.getcwd(), "uploads")
+    os.makedirs(folder, exist_ok=True)
+    return folder
+
+
+def upload_attachment(
+    reference_type: str,
+    reference_id: str,
+    file_storage: Any,
+    user_id: str | None = None,
+    remarks: str | None = None,
+) -> dict[str, Any]:
+    """Upload and attach a file to a document or master record in Cloud mode."""
+    _ensure_cloud_mode()
+
+    if not reference_type or not str(reference_type).strip():
+        raise AttachmentError("Tipo de referencia requerido.", 400)
+    if not reference_id or not str(reference_id).strip():
+        raise AttachmentError("ID de referencia requerido.", 400)
+
+    if not file_storage or not getattr(file_storage, "filename", None):
+        raise AttachmentError("No se proporcionó ningún archivo.", 400)
+
+    original_filename = secure_filename(file_storage.filename)
+    if not original_filename:
+        original_filename = "attachment"
+
+    file_storage.seek(0, os.SEEK_END)
+    file_size = file_storage.tell()
+    file_storage.seek(0)
+
+    if file_size <= 0:
+        raise AttachmentError("El archivo está vacío.", 400)
+    if file_size > MAX_FILE_SIZE:
+        raise AttachmentError("El archivo excede el tamaño máximo permitido (16 MB).", 400)
+
+    upload_folder = _get_upload_folder()
+    unique_prefix = uuid.uuid4().hex[:12]
+    saved_filename = f"{unique_prefix}_{original_filename}"
+    file_path = os.path.join(upload_folder, saved_filename)
+
+    file_storage.save(file_path)
+
+    mime_type = getattr(file_storage, "content_type", None) or "application/octet-stream"
+
+    file_record = File(
+        file_name=original_filename,
+        file_path=file_path,
+        file_size=file_size,
+        mime_type=mime_type,
+        uploaded_by=user_id,
+        remarks=remarks,
+    )
+    database.session.add(file_record)
+    database.session.flush()
+
+    attachment_record = FileAttachment(
+        file_id=file_record.id,
+        reference_type=str(reference_type).strip(),
+        reference_id=str(reference_id).strip(),
+    )
+    database.session.add(attachment_record)
+    database.session.commit()
+
+    return {
+        "file_id": file_record.id,
+        "attachment_id": attachment_record.id,
+        "file_name": file_record.file_name,
+        "file_size": file_record.file_size,
+        "mime_type": file_record.mime_type,
+        "created": file_record.created.isoformat() if file_record.created else None,
+        "uploaded_by": file_record.uploaded_by,
+        "remarks": file_record.remarks,
+    }
+
+
+def list_attachments(reference_type: str, reference_id: str) -> list[dict[str, Any]]:
+    """List all attachments linked to a reference in Cloud or Desktop mode (read-only list)."""
+    ref_type = str(reference_type).strip()
+    ref_id = str(reference_id).strip()
+
+    stmt = (
+        database.select(FileAttachment, File)
+        .join(File, FileAttachment.file_id == File.id)
+        .where(FileAttachment.reference_type == ref_type)
+        .where(FileAttachment.reference_id == ref_id)
+        .order_by(File.created.desc())
+    )
+
+    rows = database.session.execute(stmt).all()
+    attachments = []
+    for attachment, file_rec in rows:
+        attachments.append(
+            {
+                "attachment_id": attachment.id,
+                "file_id": file_rec.id,
+                "file_name": file_rec.file_name,
+                "file_size": file_rec.file_size or 0,
+                "mime_type": file_rec.mime_type or "application/octet-stream",
+                "created": file_rec.created.strftime("%Y-%m-%d %H:%M") if file_rec.created else "-",
+                "uploaded_by": file_rec.uploaded_by or "Sistema",
+                "remarks": file_rec.remarks or "",
+            }
+        )
+    return attachments
+
+
+def get_attachment_file(file_id: str) -> tuple[File, str]:
+    """Retrieve File model and verified file path for download."""
+    file_record = database.session.get(File, file_id)
+    if file_record is None:
+        raise AttachmentError("Archivo no encontrado.", 404)
+    if not file_record.file_path or not os.path.exists(file_record.file_path):
+        raise AttachmentError("El archivo físico no se encuentra en el servidor.", 404)
+    return file_record, file_record.file_path
+
+
+def delete_attachment(file_id: str, reference_type: str, reference_id: str, user_id: str | None = None) -> bool:
+    """Delete an attachment link and cleanup physical file if no other reference exists."""
+    _ensure_cloud_mode()
+
+    ref_type = str(reference_type).strip()
+    ref_id = str(reference_id).strip()
+
+    attachment = (
+        database.session.execute(
+            database.select(FileAttachment)
+            .where(FileAttachment.file_id == file_id)
+            .where(FileAttachment.reference_type == ref_type)
+            .where(FileAttachment.reference_id == ref_id)
+        )
+        .scalars()
+        .first()
+    )
+
+    if attachment is None:
+        raise AttachmentError("Adjunto no encontrado.", 404)
+
+    database.session.delete(attachment)
+    database.session.flush()
+
+    other_links = (
+        database.session.execute(
+            database.select(database.func.count(FileAttachment.id)).where(FileAttachment.file_id == file_id)
+        ).scalar()
+        or 0
+    )
+
+    if other_links == 0:
+        file_rec = database.session.get(File, file_id)
+        if file_rec:
+            if file_rec.file_path and os.path.exists(file_rec.file_path):
+                try:
+                    os.remove(file_rec.file_path)
+                except OSError:
+                    pass
+            database.session.delete(file_rec)
+
+    database.session.commit()
+    return True
+
+
+def upload_item_image(item_id: str, file_storage: Any, user_id: str | None = None) -> dict[str, Any]:
+    """Upload product image for an inventory item (Cloud mode only)."""
+    _ensure_cloud_mode()
+
+    if not item_id or not str(item_id).strip():
+        raise AttachmentError("ID de artículo requerido.", 400)
+
+    item = database.session.execute(
+        database.select(Item).where((Item.code == str(item_id).strip()) | (Item.id == str(item_id).strip()))
+    ).scalar_one_or_none()
+
+    if item is None:
+        raise AttachmentError("Artículo no encontrado.", 404)
+
+    if not file_storage or not getattr(file_storage, "filename", None):
+        raise AttachmentError("No se seleccionó una imagen.", 400)
+
+    ext = os.path.splitext(file_storage.filename)[1].lower()
+    content_type = getattr(file_storage, "content_type", "") or ""
+
+    if ext not in ALLOWED_IMAGE_EXTENSIONS and not content_type.startswith("image/"):
+        raise AttachmentError("Formato de imagen no permitido. Use PNG, JPG, WEBP, GIF o SVG.", 400)
+
+    delete_item_image(item.code, user_id=user_id, ignore_missing=True)
+
+    upload_result = upload_attachment(
+        reference_type="item_image",
+        reference_id=item.code,
+        file_storage=file_storage,
+        user_id=user_id,
+        remarks=f"Imagen del producto {item.code}",
+    )
+
+    file_rec, path = get_attachment_file(upload_result["file_id"])
+    item.image_path = path
+    database.session.commit()
+
+    return {
+        "item_id": item.code,
+        "image_path": path,
+        "file_id": file_rec.id,
+    }
+
+
+def delete_item_image(item_id: str, user_id: str | None = None, ignore_missing: bool = False) -> bool:
+    """Remove product image from an inventory item."""
+    _ensure_cloud_mode()
+
+    item = database.session.execute(
+        database.select(Item).where((Item.code == str(item_id).strip()) | (Item.id == str(item_id).strip()))
+    ).scalar_one_or_none()
+
+    if item is None:
+        if ignore_missing:
+            return False
+        raise AttachmentError("Artículo no encontrado.", 404)
+
+    attachments = (
+        database.session.execute(
+            database.select(FileAttachment)
+            .where(FileAttachment.reference_type == "item_image")
+            .where(FileAttachment.reference_id == item.code)
+        )
+        .scalars()
+        .all()
+    )
+
+    for att in attachments:
+        try:
+            delete_attachment(att.file_id, "item_image", item.code, user_id=user_id)
+        except AttachmentError:
+            pass
+
+    item.image_path = None
+    database.session.commit()
+    return True
+
+
+def get_item_image_file(item_id: str) -> tuple[File | None, str | None]:
+    """Retrieve File model and verified file path for an item's product image."""
+    item = database.session.execute(
+        database.select(Item).where((Item.code == str(item_id).strip()) | (Item.id == str(item_id).strip()))
+    ).scalar_one_or_none()
+
+    if item is None or not item.image_path or not os.path.exists(item.image_path):
+        return None, None
+
+    attachment = (
+        database.session.execute(
+            database.select(FileAttachment)
+            .where(FileAttachment.reference_type == "item_image")
+            .where(FileAttachment.reference_id == item.code)
+        )
+        .scalars()
+        .first()
+    )
+
+    file_rec = database.session.get(File, attachment.file_id) if attachment else None
+    return file_rec, item.image_path

--- a/cacao_accounting/bancos/templates/bancos/pago.html
+++ b/cacao_accounting/bancos/templates/bancos/pago.html
@@ -265,6 +265,7 @@
 {% endif %}
 
 {{ macros.document_flow_tree("payment_entry", registro) }}
+{{ macros.document_attachments_panel("payment_entry", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {{ macros.document_collaboration_panel("payment_entry", registro) }}
 {% endblock %}

--- a/cacao_accounting/compras/services.py
+++ b/cacao_accounting/compras/services.py
@@ -1648,11 +1648,12 @@ def _validate_purchase_source_link(document: Any, source_type: str, source_id: s
         if getattr(source, "purchase_order_id", None) != document.purchase_order_id:
             raise ValueError("La recepción no pertenece a la orden de compra indicada.")
     if items is not None:
+        doc_type = getattr(document, "document_type", None)
         target_types = {
             PurchaseQuotation: "purchase_quotation",
             PurchaseOrder: "purchase_order",
             PurchaseReceipt: "purchase_receipt",
-            PurchaseInvoice: PURCHASE_RETURN if document.document_type == PURCHASE_RETURN else PURCHASE_INVOICE,
+            PurchaseInvoice: PURCHASE_RETURN if doc_type == PURCHASE_RETURN else PURCHASE_INVOICE,
         }
         require_line_relations(
             target_type=target_types[type(document)],
@@ -1829,7 +1830,13 @@ def _purchase_invoice_source_ids() -> dict[str, str | None]:
 def _purchase_invoice_document_type(source_ids: dict[str, str | None]) -> str:
     """Resolve the document type for the purchase invoice."""
     doc_type = PURCHASE_INVOICE
-    if source_ids.get("from_receipt_id"):
+    is_return = (
+        request.args.get("is_return") in ("true", "True", "1", True)
+        or request.form.get("is_return") in ("true", "True", "1", True)
+        or bool(request.args.get("from_return"))
+        or bool(request.form.get("from_return"))
+    )
+    if is_return:
         doc_type = PURCHASE_RETURN
     elif source_ids.get("from_invoice_id"):
         doc_type = PURCHASE_CREDIT_NOTE
@@ -2207,8 +2214,14 @@ def _create_purchase_invoice_from_request():
             if receipt:
                 from_order = receipt.purchase_order_id
         from_invoice = request.form.get("from_invoice") or request.form.get("from_return") or None
+        is_return = (
+            request.args.get("is_return") in ("true", "True", "1", True)
+            or request.form.get("is_return") in ("true", "True", "1", True)
+            or bool(request.args.get("from_return"))
+            or bool(request.form.get("from_return"))
+        )
         document_type = PURCHASE_INVOICE
-        if from_receipt:
+        if is_return:
             document_type = PURCHASE_RETURN
         elif from_invoice:
             document_type = PURCHASE_CREDIT_NOTE

--- a/cacao_accounting/compras/templates/compras/cotizacion_proveedor.html
+++ b/cacao_accounting/compras/templates/compras/cotizacion_proveedor.html
@@ -60,5 +60,6 @@
 ) }}
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree("supplier_quotation", registro) }}
+{{ macros.document_attachments_panel("supplier_quotation", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/cacao_accounting/compras/templates/compras/factura_compra.html
+++ b/cacao_accounting/compras/templates/compras/factura_compra.html
@@ -70,5 +70,6 @@
 
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree(registro.document_type or "purchase_invoice", registro) }}
+{{ macros.document_attachments_panel(registro.document_type or "purchase_invoice", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/cacao_accounting/compras/templates/compras/import_landed_cost.html
+++ b/cacao_accounting/compras/templates/compras/import_landed_cost.html
@@ -117,5 +117,6 @@
 </div>
 
 {{ macros.document_flow_tree("import_landed_cost", registro) }}
+{{ macros.document_attachments_panel("import_landed_cost", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/cacao_accounting/compras/templates/compras/orden_compra.html
+++ b/cacao_accounting/compras/templates/compras/orden_compra.html
@@ -78,5 +78,6 @@
 
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree("purchase_order", registro) }}
+{{ macros.document_attachments_panel("purchase_order", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/cacao_accounting/compras/templates/compras/proveedor.html
+++ b/cacao_accounting/compras/templates/compras/proveedor.html
@@ -57,6 +57,8 @@
 {% set party_role = "supplier" %}
 {% include "party_detail_sections.html" %}
 
+{{ macros.document_attachments_panel("supplier", registro.id) }}
+
 {% if is_cloud_mode() %}
 <div class="ca-card mt-4">
   <div class="ca-card-header">

--- a/cacao_accounting/compras/templates/compras/recepcion.html
+++ b/cacao_accounting/compras/templates/compras/recepcion.html
@@ -68,6 +68,7 @@
 
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree("purchase_receipt", registro, create_actions_json=create_actions_json) }}
+{{ macros.document_attachments_panel("purchase_receipt", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {{ macros.document_collaboration_panel("purchase_receipt", registro) }}
 {% endblock %}

--- a/cacao_accounting/compras/templates/compras/solicitud_compra.html
+++ b/cacao_accounting/compras/templates/compras/solicitud_compra.html
@@ -62,5 +62,6 @@
 ) }}
 {{ macros.lineas_tabla_lectura(items, currency_code, show_pricing=False) }}
 {{ macros.document_flow_tree("purchase_request", registro, create_actions_json=create_actions_json) }}
+{{ macros.document_attachments_panel("purchase_request", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/cacao_accounting/compras/templates/compras/solicitud_cotizacion.html
+++ b/cacao_accounting/compras/templates/compras/solicitud_cotizacion.html
@@ -58,5 +58,6 @@
 ) }}
 {{ macros.lineas_tabla_lectura(items, currency_code, show_pricing=False) }}
 {{ macros.document_flow_tree("purchase_quotation", registro) }}
+{{ macros.document_attachments_panel("purchase_quotation", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/cacao_accounting/contabilidad/templates/contabilidad/journal.html
+++ b/cacao_accounting/contabilidad/templates/contabilidad/journal.html
@@ -541,5 +541,6 @@
 </script>
 
 {{ macros.document_flow_tree("journal_entry", registro) }}
+{{ macros.document_attachments_panel("journal_entry", registro.id) }}
 
 {% endblock %}

--- a/cacao_accounting/database/__init__.py
+++ b/cacao_accounting/database/__init__.py
@@ -1305,6 +1305,7 @@ class Item(database.Model, BaseTabla):  # type: ignore[name-defined]
     brand = database.Column(database.String(100), nullable=True)
     model_name = database.Column(database.String(100), nullable=True)
     barcode = database.Column(database.String(100), nullable=True)
+    image_path = database.Column(database.String(500), nullable=True)
     is_active = database.Column(database.Boolean(), default=True, nullable=False, index=True)
 
 
@@ -4565,6 +4566,7 @@ class File(database.Model, BaseTabla):  # type: ignore[name-defined]
     uploaded_by = database.Column(
         database.String(26), database.ForeignKey(USER_ID, ondelete=FK_RESTRICT, onupdate=FK_CASCADE), nullable=True
     )
+    remarks = database.Column(database.Text(), nullable=True)
 
 
 class FileAttachment(database.Model, BaseTabla):  # type: ignore[name-defined]

--- a/cacao_accounting/inventario/routes.py
+++ b/cacao_accounting/inventario/routes.py
@@ -347,7 +347,14 @@ def inventario_articulo_nuevo():
         if formulario.validate():
             try:
                 params = _item_params_from_form(request.form)
-                create_item_with_uoms(params)
+                item = create_item_with_uoms(params)
+                image_file = request.files.get("image") or request.files.get("product_image") or request.files.get("file")
+                if image_file and image_file.filename and is_cloud_mode():
+                    try:
+                        from cacao_accounting.attachment_service import upload_item_image
+                        upload_item_image(item.code, image_file, user_id=str(current_user.id))
+                    except Exception as exc:
+                        flash(f"Imagen no subida: {exc}", "warning")
                 database.session.commit()
                 return redirect("/inventory/item/list")
             except InventoryServiceError as exc:

--- a/cacao_accounting/inventario/routes.py
+++ b/cacao_accounting/inventario/routes.py
@@ -37,6 +37,7 @@ from cacao_accounting.document_flow.status import _
 from cacao_accounting.document_identifiers import assign_document_identifier
 
 from cacao_accounting.decorators import exige_acceso_compania, modulo_activo, verifica_permiso
+from cacao_accounting.runtime_mode import is_cloud_mode
 
 from cacao_accounting.list_filters import apply_list_filters
 

--- a/cacao_accounting/inventario/services.py
+++ b/cacao_accounting/inventario/services.py
@@ -36,6 +36,7 @@ from cacao_accounting.database.helpers import get_active_naming_series
 from cacao_accounting.database.helpers import obtener_id_modulo_por_nombre
 
 from cacao_accounting.auth.permisos import Permisos
+from cacao_accounting.runtime_mode import is_cloud_mode
 
 
 from cacao_accounting.document_flow import (

--- a/cacao_accounting/inventario/services.py
+++ b/cacao_accounting/inventario/services.py
@@ -187,6 +187,14 @@ def _process_item_edit(item, formulario):
         return None
     try:
         update_item_with_uoms(item_code=item.code, params=_item_params_from_form(request.form))
+        image_file = request.files.get("image") or request.files.get("product_image") or request.files.get("file")
+        if image_file and image_file.filename and is_cloud_mode():
+            try:
+                from cacao_accounting.attachment_service import upload_item_image
+                from flask_login import current_user
+                upload_item_image(item.code, image_file, user_id=getattr(current_user, "id", None))
+            except Exception as exc:
+                flash(f"Imagen no actualizada: {exc}", "warning")
         database.session.commit()
         flash("Artículo actualizado correctamente.", "success")
         return redirect(url_for("inventario.inventario_articulo", item_id=item.code))

--- a/cacao_accounting/inventario/templates/inventario/articulo.html
+++ b/cacao_accounting/inventario/templates/inventario/articulo.html
@@ -44,6 +44,39 @@
 
 <div class="ca-card mt-3">
   <div class="ca-card-header">
+    <h6 class="ca-card-title mb-0"><i class="bi bi-image me-1"></i>{{ _('Imagen del producto') }}</h6>
+  </div>
+  <div class="p-3 text-center">
+    {% if registro.image_path %}
+    <div class="mb-3">
+      <img src="{{ url_for('api.api_get_item_image', item_id=registro.code) }}" alt="{{ registro.name }}" class="img-thumbnail" style="max-height: 250px; object-fit: contain;">
+    </div>
+    {% if is_cloud_mode() %}
+    <form method="post" action="{{ url_for('api.api_delete_item_image', item_id=registro.code) }}" class="d-inline mb-2" onsubmit="return confirm('¿Eliminar la imagen del producto?');">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash me-1"></i>{{ _('Eliminar imagen') }}</button>
+    </form>
+    {% endif %}
+    {% else %}
+    <p class="text-muted small mb-2"><i class="bi bi-image-alt me-1"></i>{{ _('Este artículo no tiene imagen.') }}</p>
+    {% endif %}
+
+    {% if is_cloud_mode() %}
+    <form method="post" action="{{ url_for('api.api_upload_item_image', item_id=registro.code) }}" enctype="multipart/form-data" class="row g-2 align-items-center justify-content-center mt-2">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-auto">
+        <input type="file" class="form-control form-control-sm" name="file" accept="image/*" required>
+      </div>
+      <div class="col-auto">
+        <button type="submit" class="btn btn-sm btn-outline-primary"><i class="bi bi-upload me-1"></i>{{ _('Subir imagen') if not registro.image_path else _('Cambiar imagen') }}</button>
+      </div>
+    </form>
+    {% endif %}
+  </div>
+</div>
+
+<div class="ca-card mt-3">
+  <div class="ca-card-header">
     <h6 class="ca-card-title mb-0">{{ _('Clasificacion y flags') }}</h6>
   </div>
   <div class="p-3">

--- a/cacao_accounting/inventario/templates/inventario/articulo_nuevo.html
+++ b/cacao_accounting/inventario/templates/inventario/articulo_nuevo.html
@@ -22,7 +22,7 @@
       <button class="btn btn-primary btn-sm" form="form-main" type="submit"><i class="bi bi-floppy me-1"></i>{{ _('Guardar') }}</button>
     </div>
   </div>
-  <form method="post" id="form-main" class="row g-3 p-3">
+  <form method="post" id="form-main" enctype="multipart/form-data" class="row g-3 p-3">
     {{ form.csrf_token }}
 
     {# Card 1: Datos basicos #}
@@ -37,6 +37,12 @@
             {{ form.name(class="form-control form-control-sm", id="name", required=True) }}
             {% if form.name.errors %}<div class="text-danger small">{{ form.name.errors[0] }}</div>{% endif %}
           </div>
+          {% if is_cloud_mode() %}
+          <div class="col-md-3">
+            <label class="form-label" for="image">{{ _('Imagen del producto') }}</label>
+            <input class="form-control form-control-sm" type="file" id="image" name="image" accept="image/*">
+          </div>
+          {% endif %}
           <div class="col-md-3">
             <label class="form-label" for="item_category_id">{{ _('Categoria') }}</label>
             <div class="ca-smart-select" x-data='smartSelect({

--- a/cacao_accounting/inventario/templates/inventario/entrada.html
+++ b/cacao_accounting/inventario/templates/inventario/entrada.html
@@ -59,6 +59,7 @@
 ) }}
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree("stock_entry", registro) }}
+{{ macros.document_attachments_panel("stock_entry", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {{ macros.document_collaboration_panel("stock_entry", registro) }}
 {% endblock %}

--- a/cacao_accounting/templates/macros.html
+++ b/cacao_accounting/templates/macros.html
@@ -427,6 +427,97 @@
 {% endif %}
 {% endmacro %}
 
+{# ─── Document / Master Record Attachments Panel ───────────────── #}
+{% macro document_attachments_panel(reference_type, reference_id) %}
+{% set attachments = get_document_attachments(reference_type, reference_id) %}
+<div class="ca-card mt-3" x-data="{ open: false }">
+  <div class="ca-card-header" role="button" tabindex="0" @click="open = !open" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
+    <div class="d-flex align-items-center gap-2">
+      <i class="bi bi-paperclip me-1"></i>
+      <h6 class="ca-card-title mb-0">{{ _('Archivos adjuntos') }}</h6>
+      {% if attachments %}
+      <span class="badge bg-secondary rounded-pill">{{ attachments | length }}</span>
+      {% endif %}
+    </div>
+    <button class="btn btn-sm btn-outline-secondary" type="button" @click.stop="open = !open" :aria-expanded="open.toString()">
+      <i class="bi" :class="open ? 'bi-chevron-up' : 'bi-chevron-down'"></i>
+    </button>
+  </div>
+
+  <div class="p-3" x-show="open" x-cloak>
+    {% if is_cloud_mode() %}
+    <form method="post" action="{{ url_for('api.api_upload_attachment', reference_type=reference_type, reference_id=reference_id) }}" enctype="multipart/form-data" class="row g-2 align-items-end mb-3">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="col-md-5">
+        <label class="form-label small fw-semibold" for="attachment-file-{{ reference_id }}">{{ _('Seleccionar archivo') }}</label>
+        <input type="file" class="form-control form-control-sm" id="attachment-file-{{ reference_id }}" name="file" required>
+      </div>
+      <div class="col-md-5">
+        <label class="form-label small fw-semibold" for="attachment-remarks-{{ reference_id }}">{{ _('Observaciones / Descripción') }}</label>
+        <input type="text" class="form-control form-control-sm" id="attachment-remarks-{{ reference_id }}" name="remarks" placeholder="{{ _('Opcional...') }}" maxlength="255">
+      </div>
+      <div class="col-md-2">
+        <button type="submit" class="btn btn-sm btn-primary w-100"><i class="bi bi-upload me-1"></i>{{ _('Subir adjunto') }}</button>
+      </div>
+    </form>
+    {% endif %}
+
+    {% if attachments %}
+    <div class="table-responsive">
+      <table class="table table-sm align-middle mb-0">
+        <caption class="visually-hidden">{{ _('Archivos adjuntos') }}</caption>
+        <thead>
+          <tr>
+            <th>{{ _('Archivo') }}</th>
+            <th>{{ _('Tamaño') }}</th>
+            <th>{{ _('Fecha de subida') }}</th>
+            <th>{{ _('Observaciones') }}</th>
+            <th class="text-end">{{ _('Acciones') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for att in attachments %}
+          <tr>
+            <td>
+              <i class="bi bi-file-earmark me-1 text-primary"></i>
+              <a href="{{ url_for('api.api_download_attachment', file_id=att.file_id) }}" target="_blank" class="fw-semibold link-dark">
+                {{ att.file_name }}
+              </a>
+            </td>
+            <td>{{ (att.file_size / 1024)|round(1) }} KB</td>
+            <td>{{ att.created }}</td>
+            <td>{{ att.remarks or '-' }}</td>
+            <td class="text-end">
+              <a href="{{ url_for('api.api_download_attachment', file_id=att.file_id) }}" class="btn btn-sm btn-outline-primary py-0 px-2" title="{{ _('Descargar') }}">
+                <i class="bi bi-download"></i>
+              </a>
+              {% if is_cloud_mode() %}
+              <form method="post" action="{{ url_for('api.api_delete_attachment', file_id=att.file_id) }}" class="d-inline" onsubmit="return confirm('¿Eliminar este archivo adjunto?');">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="reference_type" value="{{ reference_type }}">
+                <input type="hidden" name="reference_id" value="{{ reference_id }}">
+                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-2" title="{{ _('Eliminar') }}">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </form>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+      {% if is_cloud_mode() %}
+      <p class="text-muted small mb-0"><i class="bi bi-info-circle me-1"></i>{{ _('No hay archivos adjuntos.') }}</p>
+      {% else %}
+      <p class="text-muted small mb-0"><i class="bi bi-info-circle me-1"></i>{{ _('La subida de archivos no está disponible en modo escritorio.') }}</p>
+      {% endif %}
+    {% endif %}
+  </div>
+</div>
+{% endmacro %}
+
 {# ─────────────────────────────────────────────────────────────── #}
 {# Árbol de flujo documental — componente reutilizable              #}
 {#                                                                   #}

--- a/cacao_accounting/ventas/templates/ventas/cliente.html
+++ b/cacao_accounting/ventas/templates/ventas/cliente.html
@@ -57,6 +57,8 @@
 {% set party_role = "customer" %}
 {% include "party_detail_sections.html" %}
 
+{{ macros.document_attachments_panel("customer", registro.id) }}
+
 {% if is_cloud_mode() %}
 <div class="ca-card mt-4">
   <div class="ca-card-header">

--- a/cacao_accounting/ventas/templates/ventas/cotizacion.html
+++ b/cacao_accounting/ventas/templates/ventas/cotizacion.html
@@ -58,5 +58,6 @@
 ) }}
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree("sales_quotation", registro) }}
+{{ macros.document_attachments_panel("sales_quotation", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/cacao_accounting/ventas/templates/ventas/entrega.html
+++ b/cacao_accounting/ventas/templates/ventas/entrega.html
@@ -56,6 +56,7 @@
 ) }}
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree("delivery_note", registro) }}
+{{ macros.document_attachments_panel("delivery_note", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {{ macros.document_collaboration_panel("delivery_note", registro) }}
 {% endblock %}

--- a/cacao_accounting/ventas/templates/ventas/factura_venta.html
+++ b/cacao_accounting/ventas/templates/ventas/factura_venta.html
@@ -60,5 +60,6 @@
 ) }}
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree(registro.document_type or "sales_invoice", registro) }}
+{{ macros.document_attachments_panel(registro.document_type or "sales_invoice", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/cacao_accounting/ventas/templates/ventas/orden_venta.html
+++ b/cacao_accounting/ventas/templates/ventas/orden_venta.html
@@ -57,5 +57,6 @@
 ) }}
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree("sales_order", registro) }}
+{{ macros.document_attachments_panel("sales_order", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/cacao_accounting/ventas/templates/ventas/solicitud_venta.html
+++ b/cacao_accounting/ventas/templates/ventas/solicitud_venta.html
@@ -58,5 +58,6 @@
 ) }}
 {{ macros.lineas_tabla_lectura(items, currency_code) }}
 {{ macros.document_flow_tree("sales_request", registro) }}
+{{ macros.document_attachments_panel("sales_request", registro.id) }}
 {{ macros.audit_timeline(audit_timeline) }}
 {% endblock %}

--- a/tests/test_attachment_service.py
+++ b/tests/test_attachment_service.py
@@ -16,7 +16,7 @@ from cacao_accounting.attachment_service import (
     upload_attachment,
     upload_item_image,
 )
-from cacao_accounting.database import Item, User, database
+from cacao_accounting.database import Item, Party, User, database
 from werkzeug.datastructures import FileStorage
 
 
@@ -161,6 +161,17 @@ def test_item_product_image_flow_cloud(app_cloud, tmp_path):
             assert img_path is not None
             assert open(img_path, "rb").read() == image_bytes
 
+            invalid_replacement = FileStorage(
+                stream=io.BytesIO(b"not an image"),
+                filename="replacement.png",
+                content_type="image/png",
+            )
+            with pytest.raises(AttachmentError, match="contenido"):
+                upload_item_image("ITEM-TEST-01", invalid_replacement, user_id="user123")
+            preserved_file, preserved_path = get_item_image_file("ITEM-TEST-01")
+            assert preserved_file is not None
+            assert preserved_path == img_path
+
             # Test deleting item image
             delete_item_image("ITEM-TEST-01", user_id="user123")
 
@@ -221,6 +232,9 @@ def test_api_attachment_routes(app_cloud, tmp_path):
         )
         database.session.add(user)
 
+        supplier = Party(code="SUPP-API-01", name="Proveedor API", is_supplier=True, is_active=True)
+        database.session.add(supplier)
+
         item = Item(
             code="ITEM-API-01",
             name="Cacao en Polvo",
@@ -239,13 +253,17 @@ def test_api_attachment_routes(app_cloud, tmp_path):
                 "file": (io.BytesIO(b"Supplier Invoice PDF"), "inv_456.pdf"),
                 "remarks": "Factura recibida",
             }
-            res = client.post("/api/attachments/purchase_invoice/INV-001/upload", data=data, content_type="multipart/form-data")
+            res = client.post(
+                f"/api/attachments/supplier/{supplier.id}/upload",
+                data=data,
+                content_type="multipart/form-data",
+            )
             assert res.status_code == 201
             json_res = res.get_json()
             file_id = json_res["file_id"]
 
             # List attachments
-            res_list = client.get("/api/attachments/purchase_invoice/INV-001")
+            res_list = client.get(f"/api/attachments/supplier/{supplier.id}")
             assert res_list.status_code == 200
             attachments_list = res_list.get_json()
             assert len(attachments_list) == 1
@@ -257,12 +275,15 @@ def test_api_attachment_routes(app_cloud, tmp_path):
             assert res_dl.data == b"Supplier Invoice PDF"
 
             # Delete attachment
-            res_del = client.post(f"/api/attachments/{file_id}/delete", json={"reference_type": "purchase_invoice", "reference_id": "INV-001"})
+            res_del = client.post(
+                f"/api/attachments/{file_id}/delete",
+                json={"reference_type": "supplier", "reference_id": supplier.id},
+            )
             assert res_del.status_code == 200
 
             # Upload Item image via API
             data_img = {
-                "file": (io.BytesIO(b"\x89PNGfakeimage"), "cacao.png"),
+                "file": (io.BytesIO(b"\x89PNG\r\n\x1a\nfakeimage"), "cacao.png"),
             }
             res_img = client.post("/api/inventory/items/ITEM-API-01/image", data=data_img, content_type="multipart/form-data")
             assert res_img.status_code == 200
@@ -270,7 +291,7 @@ def test_api_attachment_routes(app_cloud, tmp_path):
             # Serve Item image via API
             res_get_img = client.get("/api/inventory/items/ITEM-API-01/image")
             assert res_get_img.status_code == 200
-            assert res_get_img.data == b"\x89PNGfakeimage"
+            assert res_get_img.data == b"\x89PNG\r\n\x1a\nfakeimage"
 
             # Delete Item image via API
             res_del_img = client.post("/api/inventory/items/ITEM-API-01/image/delete")

--- a/tests/test_attachment_service.py
+++ b/tests/test_attachment_service.py
@@ -1,0 +1,277 @@
+"""Tests for Cloud-only file attachment service and item product images."""
+
+import io
+from unittest.mock import patch
+
+import pytest
+
+from cacao_accounting import create_app
+from cacao_accounting.attachment_service import (
+    AttachmentError,
+    delete_attachment,
+    delete_item_image,
+    get_attachment_file,
+    get_item_image_file,
+    list_attachments,
+    upload_attachment,
+    upload_item_image,
+)
+from cacao_accounting.database import Item, User, database
+from werkzeug.datastructures import FileStorage
+
+
+@pytest.fixture
+def app_cloud():
+    """Create test application instance in Cloud mode."""
+    app = create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "SECRET_KEY": "test-secret-key-cloud",
+            "WTF_CSRF_ENABLED": False,
+        }
+    )
+    with app.app_context():
+        database.create_all()
+        yield app
+        database.session.remove()
+        database.drop_all()
+
+
+def test_attachment_upload_and_list_cloud(app_cloud, tmp_path):
+    """Test uploading and listing attachments in Cloud mode."""
+    with app_cloud.app_context():
+        app_cloud.config["UPLOAD_FOLDER"] = str(tmp_path)
+
+        file_content = b"Mock PDF quotation content"
+        file_obj = FileStorage(
+            stream=io.BytesIO(file_content),
+            filename="quotation_123.pdf",
+            content_type="application/pdf",
+        )
+
+        with patch("cacao_accounting.attachment_service.is_desktop_mode", return_value=False):
+            result = upload_attachment(
+                reference_type="supplier_quotation",
+                reference_id="SQ-0001",
+                file_storage=file_obj,
+                user_id="user123",
+                remarks="Cotización enviada por proveedor A",
+            )
+
+            assert result["file_name"] == "quotation_123.pdf"
+            assert result["file_size"] == len(file_content)
+            assert result["mime_type"] == "application/pdf"
+
+            attachments = list_attachments("supplier_quotation", "SQ-0001")
+            assert len(attachments) == 1
+            assert attachments[0]["file_name"] == "quotation_123.pdf"
+            assert attachments[0]["remarks"] == "Cotización enviada por proveedor A"
+
+            file_rec, path = get_attachment_file(result["file_id"])
+            assert file_rec.file_name == "quotation_123.pdf"
+            assert open(path, "rb").read() == file_content
+
+
+def test_attachment_delete_cloud(app_cloud, tmp_path):
+    """Test deleting an attachment removes DB links and physical file."""
+    with app_cloud.app_context():
+        app_cloud.config["UPLOAD_FOLDER"] = str(tmp_path)
+
+        file_obj = FileStorage(
+            stream=io.BytesIO(b"Sample supplier document"),
+            filename="supplier_id_card.pdf",
+            content_type="application/pdf",
+        )
+
+        with patch("cacao_accounting.attachment_service.is_desktop_mode", return_value=False):
+            upload_res = upload_attachment(
+                reference_type="supplier",
+                reference_id="SUPP-01",
+                file_storage=file_obj,
+                user_id="user123",
+            )
+
+            file_id = upload_res["file_id"]
+            attachments = list_attachments("supplier", "SUPP-01")
+            assert len(attachments) == 1
+
+            delete_attachment(file_id, "supplier", "SUPP-01", user_id="user123")
+
+            attachments_after = list_attachments("supplier", "SUPP-01")
+            assert len(attachments_after) == 0
+
+            with pytest.raises(AttachmentError) as exc_info:
+                get_attachment_file(file_id)
+            assert exc_info.value.status_code == 404
+
+
+def test_desktop_mode_blocks_attachments(app_cloud):
+    """Test that Desktop mode strictly blocks file upload and deletion with 403."""
+    with app_cloud.app_context():
+        file_obj = FileStorage(
+            stream=io.BytesIO(b"Desktop test content"),
+            filename="test.txt",
+            content_type="text/plain",
+        )
+
+        with patch("cacao_accounting.attachment_service.is_desktop_mode", return_value=True):
+            with pytest.raises(AttachmentError) as exc_info:
+                upload_attachment(
+                    reference_type="purchase_order",
+                    reference_id="PO-001",
+                    file_storage=file_obj,
+                )
+            assert exc_info.value.status_code == 403
+            assert "modo escritorio" in str(exc_info.value)
+
+            with pytest.raises(AttachmentError) as exc_info2:
+                delete_attachment("file123", "purchase_order", "PO-001")
+            assert exc_info2.value.status_code == 403
+
+
+def test_item_product_image_flow_cloud(app_cloud, tmp_path):
+    """Test inventory item product image upload, retrieval, and deletion in Cloud mode."""
+    with app_cloud.app_context():
+        app_cloud.config["UPLOAD_FOLDER"] = str(tmp_path)
+
+        # Create sample item
+        item = Item(
+            code="ITEM-TEST-01",
+            name="Café Orgánico 500g",
+            item_type="goods",
+            default_uom="KG",
+        )
+        database.session.add(item)
+        database.session.commit()
+
+        image_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+        image_obj = FileStorage(
+            stream=io.BytesIO(image_bytes),
+            filename="product_cafe.png",
+            content_type="image/png",
+        )
+
+        with patch("cacao_accounting.attachment_service.is_desktop_mode", return_value=False):
+            upload_res = upload_item_image("ITEM-TEST-01", image_obj, user_id="user123")
+            assert upload_res["item_id"] == "ITEM-TEST-01"
+
+            file_rec, img_path = get_item_image_file("ITEM-TEST-01")
+            assert file_rec is not None
+            assert img_path is not None
+            assert open(img_path, "rb").read() == image_bytes
+
+            # Test deleting item image
+            delete_item_image("ITEM-TEST-01", user_id="user123")
+
+            file_rec_after, path_after = get_item_image_file("ITEM-TEST-01")
+            assert file_rec_after is None
+            assert path_after is None
+
+
+def test_item_product_image_invalid_type_and_desktop_block(app_cloud):
+    """Test non-image file validation and Desktop mode blocking for product images."""
+    with app_cloud.app_context():
+        item = Item(
+            code="ITEM-TEST-02",
+            name="Harina de Maíz",
+            item_type="goods",
+            default_uom="KG",
+        )
+        database.session.add(item)
+        database.session.commit()
+
+        txt_file = FileStorage(
+            stream=io.BytesIO(b"not an image"),
+            filename="doc.txt",
+            content_type="text/plain",
+        )
+
+        with patch("cacao_accounting.attachment_service.is_desktop_mode", return_value=False):
+            with pytest.raises(AttachmentError) as exc_info:
+                upload_item_image("ITEM-TEST-02", txt_file)
+            assert exc_info.value.status_code == 400
+            assert "Formato de imagen no permitido" in str(exc_info.value)
+
+        image_file = FileStorage(
+            stream=io.BytesIO(b"\x89PNG"),
+            filename="valid.png",
+            content_type="image/png",
+        )
+
+        with patch("cacao_accounting.attachment_service.is_desktop_mode", return_value=True):
+            with pytest.raises(AttachmentError) as exc_info2:
+                upload_item_image("ITEM-TEST-02", image_file)
+            assert exc_info2.value.status_code == 403
+            assert "modo escritorio" in str(exc_info2.value)
+
+
+def test_api_attachment_routes(app_cloud, tmp_path):
+    """Test HTTP API endpoints for attachments and product images."""
+    app_cloud.config["UPLOAD_FOLDER"] = str(tmp_path)
+    client = app_cloud.test_client()
+
+    with app_cloud.app_context():
+        user = User(
+            user="admin_test",
+            e_mail="admin@example.com",
+            password=b"secret_hash",
+            classification="admin",
+            active=True,
+        )
+        database.session.add(user)
+
+        item = Item(
+            code="ITEM-API-01",
+            name="Cacao en Polvo",
+            item_type="goods",
+            default_uom="KG",
+        )
+        database.session.add(item)
+        database.session.commit()
+
+        with client.session_transaction() as sess:
+            sess["_user_id"] = user.id
+
+        with patch("cacao_accounting.attachment_service.is_desktop_mode", return_value=False):
+            # Upload attachment
+            data = {
+                "file": (io.BytesIO(b"Supplier Invoice PDF"), "inv_456.pdf"),
+                "remarks": "Factura recibida",
+            }
+            res = client.post("/api/attachments/purchase_invoice/INV-001/upload", data=data, content_type="multipart/form-data")
+            assert res.status_code == 201
+            json_res = res.get_json()
+            file_id = json_res["file_id"]
+
+            # List attachments
+            res_list = client.get("/api/attachments/purchase_invoice/INV-001")
+            assert res_list.status_code == 200
+            attachments_list = res_list.get_json()
+            assert len(attachments_list) == 1
+            assert attachments_list[0]["file_name"] == "inv_456.pdf"
+
+            # Download attachment
+            res_dl = client.get(f"/attachments/download/{file_id}")
+            assert res_dl.status_code == 200
+            assert res_dl.data == b"Supplier Invoice PDF"
+
+            # Delete attachment
+            res_del = client.post(f"/api/attachments/{file_id}/delete", json={"reference_type": "purchase_invoice", "reference_id": "INV-001"})
+            assert res_del.status_code == 200
+
+            # Upload Item image via API
+            data_img = {
+                "file": (io.BytesIO(b"\x89PNGfakeimage"), "cacao.png"),
+            }
+            res_img = client.post("/api/inventory/items/ITEM-API-01/image", data=data_img, content_type="multipart/form-data")
+            assert res_img.status_code == 200
+
+            # Serve Item image via API
+            res_get_img = client.get("/api/inventory/items/ITEM-API-01/image")
+            assert res_get_img.status_code == 200
+            assert res_get_img.data == b"\x89PNGfakeimage"
+
+            # Delete Item image via API
+            res_del_img = client.post("/api/inventory/items/ITEM-API-01/image/delete")
+            assert res_del_img.status_code == 200


### PR DESCRIPTION
Adds support for file attachments in Cloud mode (blocked in Desktop mode) across all operational documents and master records (suppliers and customers) via a collapsible panel UI, and adds product image support for inventory items.

---
*PR created automatically by Jules for task [18066687643287222135](https://jules.google.com/task/18066687643287222135) started by @williamjmorenor*