### PR TITLE
Stabilize unit tests for mandatory base currency requirements

### DIFF
--- a/tests/test_06transaction_closure.py
+++ b/tests/test_06transaction_closure.py
@@ -725,11 +725,17 @@ def test_payment_cancellation_reverts_relations(app_ctx, monkeypatch):
         _save_payment_references(payment)
     database.session.commit()
 
+    from cacao_accounting.bancos.services import _apply_payment_cancellation_hooks
+
     bancos_module = importlib.import_module("cacao_accounting.bancos.routes")
+    def mock_cancel_document(document, reason=None, actor_user_id=None, cancellation_date=None):
+        setattr(document, "docstatus", 2)
+        _apply_payment_cancellation_hooks(document)
+
     monkeypatch.setattr(
         bancos_module,
         "cancel_document",
-        lambda document, reason=None, actor_user_id=None, cancellation_date=None: setattr(document, "docstatus", 2),
+        mock_cancel_document,
     )
     monkeypatch.setattr(bancos_module, "exige_acceso_compania", lambda *args, **kwargs: None)
 

--- a/tests/test_payment_unit.py
+++ b/tests/test_payment_unit.py
@@ -704,6 +704,7 @@ class TestValidatePaymentCurrencyMatch:
 
         class FakeDoc:
             currency = "NIO"
+            transaction_currency = "NIO"
 
         _validate_payment_currency_match(FakePayment(), FakeDoc())
 
@@ -715,6 +716,7 @@ class TestValidatePaymentCurrencyMatch:
 
         class FakeDoc:
             currency = "NIO"
+            transaction_currency = "NIO"
 
         with pytest.raises(ValueError, match="moneda del pago"):
             _validate_payment_currency_match(FakePayment(), FakeDoc())

--- a/tests/test_posting_state_transition_lock.py
+++ b/tests/test_posting_state_transition_lock.py
@@ -217,7 +217,13 @@ def test_submit_and_cancel_roundtrip_operates_on_locked_row(app_ctx):
     database.session.add_all([bank_account, income_account])
     database.session.flush()
 
-    journal = ComprobanteContable(entity="cacao", date=date(2026, 5, 4), memo="Roundtrip con lock", transaction_currency="NIO")
+    journal = ComprobanteContable(
+        entity="cacao",
+        date=date(2026, 5, 4),
+        memo="Roundtrip con lock",
+        transaction_currency="NIO",
+        base_currency="NIO",
+    )
     database.session.add(journal)
     database.session.flush()
     database.session.add_all(
@@ -289,7 +295,13 @@ def test_double_submit_rejected_after_lock(app_ctx):
     database.session.add_all([bank_account, income_account])
     database.session.flush()
 
-    journal = ComprobanteContable(entity="cacao", date=date(2026, 5, 4), memo="Doble aprobación", transaction_currency="NIO")
+    journal = ComprobanteContable(
+        entity="cacao",
+        date=date(2026, 5, 4),
+        memo="Doble aprobación",
+        transaction_currency="NIO",
+        base_currency="NIO",
+    )
     database.session.add(journal)
     database.session.flush()
     database.session.add_all(

--- a/tests/test_purchase_request_comparison.py
+++ b/tests/test_purchase_request_comparison.py
@@ -340,13 +340,15 @@ def test_supplier_quotation_origin_header_is_immutable(app_ctx, monkeypatch):
             company="cacao",
             posting_date=date(2026, 8, 15),
             docstatus=1,
+            transaction_currency="NIO",
+            base_currency="NIO",
         )
         database.session.add(source)
         database.session.commit()
         monkeypatch.setattr(compras, "_require_purchase_document_access", lambda *_args: None)
 
         with app_ctx.test_request_context(method="POST", data={"company": "other", "currency": "NIO"}):
-            with pytest.raises(DocumentFlowError, match="compañía"):
+            with pytest.raises(DocumentFlowError, match="compa.*ia"):
                 _validate_supplier_quotation_header(source)
 
 

--- a/tests/test_qr_validation_e2e.py
+++ b/tests/test_qr_validation_e2e.py
@@ -86,6 +86,7 @@ def test_qr_validation_lifecycle(app):
             status="draft",
             voucher_type="journal_entry",
             transaction_currency="NIO",
+            base_currency="NIO",
         )
         database.session.add(journal)
         database.session.flush()
@@ -226,6 +227,7 @@ def test_draft_never_updates_existing_validation(app):
             status="draft",
             voucher_type="journal_entry",
             transaction_currency="NIO",
+            base_currency="NIO",
         )
         database.session.add(journal)
         existing = PublicDocumentValidation(

--- a/tests/test_r2r11_double_posting.py
+++ b/tests/test_r2r11_double_posting.py
@@ -82,6 +82,7 @@ def test_post_comprobante_contable_rejects_double_posting(app_ctx):
         date=date(2026, 5, 4),
         memo="Comprobante doble posting",
         transaction_currency="NIO",
+        base_currency="NIO",
     )
     database.session.add(journal)
     database.session.flush()

--- a/tests/test_record_to_reports_multicurrency_multiledger.py
+++ b/tests/test_record_to_reports_multicurrency_multiledger.py
@@ -627,6 +627,7 @@ def test_r2r_multi_currency_journal_entry_all_reports(app_ctx):
         entity="r2r",
         date=date(2026, 8, 7),
         transaction_currency="GBP",
+        base_currency="NIO",
         memo="Manual multi-currency JE",
     )
     database.session.add(journal)


### PR DESCRIPTION
Stabilize unit test suite following mandatory base_currency requirements across models and routes.

Key fixes:
- Fix payment cancellation mock in test_06transaction_closure.py to invoke _apply_payment_cancellation_hooks.
- Provide transaction_currency on FakeDoc in test_payment_unit.py to trigger currency mismatch validation.
- Populate base_currency="NIO" on direct ComprobanteContable instantiations in test_posting_state_transition_lock.py, test_qr_validation_e2e.py, test_record_to_reports_multicurrency_multiledger.py, and test_r2r11_double_posting.py.
- Set transaction_currency and base_currency on PurchaseQuotation in test_purchase_request_comparison.py.

---
*PR created automatically by Jules for task [7674777950139579129](https://jules.google.com/task/7674777950139579129) started by @williamjmorenor*