### PR TITLE
Fix test_report_pdf_export under CACAO_ACCOUNTING_DESKTOP=True

### DIFF
--- a/tests/test_report_pdf_export.py
+++ b/tests/test_report_pdf_export.py
@@ -49,7 +49,7 @@ class _FakeReport:
 
 def _make_app(desktop: bool):
     """Aplica de prueba con o sin el modo escritorio."""
-    extra = {"MODO_ESCRITORIO": True} if desktop else {}
+    extra = {"MODO_ESCRITORIO": desktop}
     app = create_app(
         {
             **configuracion,


### PR DESCRIPTION
Explicitly set MODO_ESCRITORIO in test app configuration helper so that desktop=False correctly overrides CACAO_ACCOUNTING_DESKTOP=True environment variable.

---
*PR created automatically by Jules for task [5725059771045829512](https://jules.google.com/task/5725059771045829512) started by @williamjmorenor*